### PR TITLE
Enable view for mucoll envirionments

### DIFF
--- a/environments/mucoll-common/spack.yaml
+++ b/environments/mucoll-common/spack.yaml
@@ -1,4 +1,3 @@
 spack:
   include:
   - packages.yaml
-  view: false

--- a/environments/mucoll-release-debug/spack.yaml
+++ b/environments/mucoll-release-debug/spack.yaml
@@ -1,7 +1,6 @@
 spack:
   include:
   - packages.yaml
-  view: false
   packages:
     all:
       variants: build_type=Debug cxxstd=17

--- a/environments/mucoll-release/spack.yaml
+++ b/environments/mucoll-release/spack.yaml
@@ -1,4 +1,3 @@
 spack:
   include:
   - packages.yaml
-  view: false


### PR DESCRIPTION
This makes it easy to setup the necessary paths of the installed packages using "official" spack method.