### PR TITLE
Enable Pandora monitoring for debugging Pandora

### DIFF
--- a/environments/mucoll-release/spack.yaml
+++ b/environments/mucoll-release/spack.yaml
@@ -33,6 +33,10 @@ spack:
       require: '@1.3.1'
     muoncvxddigitiser:
       require: '@0.2.1'
+    ddmarlinpandora:
+      require: +monitoring
+    lccontent:
+      require: +monitoring
 
     # Use the system OpenGL as recommended by spack
     # See https://github.com/key4hep/key4hep-spack/issues/318 and

--- a/packages/ddmarlinpandora/package.py
+++ b/packages/ddmarlinpandora/package.py
@@ -29,6 +29,9 @@ class Ddmarlinpandora(CMakePackage, MCIlcsoftpackage):
     depends_on("larcontent")
     depends_on('dd4hep')
     depends_on('marlintrk')
+    depends_on("pandoramonitoring", when="+monitoring")
+
+    variant("monitoring", default=False, description="Enable Pandora Monitoring")
 
     def setup_run_environment(self, spack_env):
         spack_env.prepend_path('MARLIN_DLL', self.prefix.lib + "/libDDMarlinPandora.so")
@@ -36,5 +39,6 @@ class Ddmarlinpandora(CMakePackage, MCIlcsoftpackage):
     def cmake_args(self):
         # C++ Standard
         return [
-            '-DCMAKE_CXX_STANDARD=%s' % self.spec['root'].variants['cxxstd'].value
+            '-DCMAKE_CXX_STANDARD=%s' % self.spec['root'].variants['cxxstd'].value,
+            self.define_from_variant("PANDORA_MONITORING", "monitoring"),
         ]


### PR DESCRIPTION
Adding a `+monitoring` variant to `ddmarlinpandora` ([similar to how it is done in key4hep-spack](https://github.com/key4hep/key4hep-spack/blob/5e5384a4e5bba9ca834f3a56cebfbca1255e6f80/packages/ddmarlinpandora/package.py#L50-L52)) and building the stack with that by default.