### PR TITLE
Update ddhep version to 1.31

### DIFF
--- a/environments/mucoll-release/spack.yaml
+++ b/environments/mucoll-release/spack.yaml
@@ -23,6 +23,8 @@ spack:
       require: '@0.25'
     lcgeo:
       require: '@0.20'
+    k4geo:
+      require: '@master'
     forwardtracking:
       require: '@1.14.2'
     conformaltracking:

--- a/environments/mucoll-release/spack.yaml
+++ b/environments/mucoll-release/spack.yaml
@@ -24,7 +24,7 @@ spack:
     lcgeo:
       require: '@0.20'
     k4geo:
-      require: '@master'
+      require: '@main'
     forwardtracking:
       require: '@1.14.2'
     conformaltracking:

--- a/environments/mucoll-release/spack.yaml
+++ b/environments/mucoll-release/spack.yaml
@@ -17,7 +17,7 @@ spack:
       require: '@6.32: +davix+fftw+gsl+math+minuit+mlp+opengl~postgres~pythia8+python+r+roofit+root7+rpath~shadow+spectrum+sqlite+ssl+tbb+threads+tmva+tmva-cpu+unuran+vc+vdt+x+xml+xrootd cxxstd=20'
 
     dd4hep:
-      require: '@1.30: +edm4hep+lcio+xercesc+hepmc3'
+      require: '@1.31: +edm4hep+lcio+xercesc+hepmc3'
 
     overlay:
       require: '@0.25'

--- a/environments/mucoll-release/spack.yaml
+++ b/environments/mucoll-release/spack.yaml
@@ -23,8 +23,6 @@ spack:
       require: '@0.25'
     lcgeo:
       require: '@0.20'
-    lcio:
-      require: '@2.22.4'
     forwardtracking:
       require: '@1.14.2'
     conformaltracking:

--- a/environments/mucoll-release/spack.yaml
+++ b/environments/mucoll-release/spack.yaml
@@ -22,7 +22,7 @@ spack:
     overlay:
       require: '@0.25'
     lcgeo:
-      require: '@0.20'
+      require: '@0.21'
     k4geo:
       require: '@main'
     forwardtracking:

--- a/packages/lcgeo/package.py
+++ b/packages/lcgeo/package.py
@@ -18,7 +18,8 @@ class Lcgeo(CMakePackage, MCIlcsoftpackage):
     maintainers = ['gianelle', 'pandreetto']
 
     version('master',  branch='master')
-    version('0.20', sha256='7afdb3ad06b577481ca17003981b2dc8182d5c49ac032a3ee20ae545d97695e1', preferred=True)
+    version('0.21',    sha256='72fe0c480321ebbfbe7300da02d970ab3357f00c7ac0035eb8dec3db4271ead5', preferred=True)
+    version('0.20',    sha256='7afdb3ad06b577481ca17003981b2dc8182d5c49ac032a3ee20ae545d97695e1')
     version("0.18.1",  sha256="5fcfcbd6110792bb607aba82a8dcbf887b40065aa12835f720af700f26c53bcc")
     version("0.18",    sha256="271062288aac419ce6affc98e199c597c340be57830c30f3b3e1d774cccc608b")
     version('0.17',    sha256='5ab33aaf5bc37deba82c2dde78cdce6c0041257222ed7ea052ecdd388a41cf9b')


### PR DESCRIPTION
This PR updates dd4hep to 1.31 as requested by @samf25 and @angirar.

The lcgeo tag was bumped correspondingly. k4geo is set to main to pick up untagged fixes for now.

