### PR TITLE
Update readme and concretization test

### DIFF
--- a/.github/workflows/concretize-template.yaml
+++ b/.github/workflows/concretize-template.yaml
@@ -6,43 +6,39 @@ on:
       target:
         required: true
         type: string
+      os:
+        required: true
+        type: string
+
 jobs:
   concretize:
     runs-on: ubuntu-latest
+    container: ghcr.io/key4hep/key4hep-externals-${{inputs.os}}:main
     strategy:
       fail-fast: false
     steps:
-      - name: Checkout Spack
+      - name: Checkout Mucoll Spack
         uses: actions/checkout@v4
         with:
-          repository: spack/spack
-          path: spack
-          ref: 6cb16c39ab85fbc211e50be804fa7a15f24ccebc
-
-      - name: Checkout Key4hep
-        uses: actions/checkout@v4
-        with:
-          repository: key4hep/key4hep-spack
-          path: key4hep-spack
-          ref: 334aa25cf90cbbaf693ac29509d4d7b790effecb
-
-      - name: Checkout this repo
-        uses: actions/checkout@v4
-        with:
+          fetch-depth: 0
           path: mucoll-spack
-
-      - name: Concretize mucoll-common
+          ref:  ${{ github.sha }}
+      - name: Apply Patches
+        shell: spack-bash {0}
         run: |
-          source spack/share/spack/setup-env.sh
+          whereami=$(pwd)
+          cd /opt/spack 
+          . ${whereami}/mucoll-spack/.cherry-pick
+          cd -
+      - name: Load env and concretize
+        shell: spack-bash {0}
+        run: |
+          . /opt/setup_spack.sh
           spack --version
-          spack repo add key4hep-spack
           spack repo add mucoll-spack
-          spack compiler find
           spack env activate mucoll-spack/environments/mucoll-${{ inputs.target }}
-          spack add mucoll-stack %gcc@11:
-          spack concretize
+          spack concretize --reuse
           spack spec -Nt > ${GITHUB_WORKSPACE}/spec-${{ inputs.target }}.log
-
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/concretize.yaml
+++ b/.github/workflows/concretize.yaml
@@ -1,4 +1,4 @@
-name: concretize-ubuntu
+name: Concretize Stack
 
 on: [pull_request]
 
@@ -7,7 +7,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [alma9, ubuntu24]
         target: [common, release, release-debug]
     uses: ./.github/workflows/concretize-template.yaml
     with:
       target: ${{ matrix.target }}
+      os: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # [Spack](https://github.com/spack/spack) package repository for Muon Collider software stack
 
-This repository holds a set of Spack recipes for Muon Collider software (under namespace `mucoll`) based on [Key4hep](https://key4hep.github.io/key4hep-doc/) stack. It extends the corresponding [key4hep-stack](https://github.com/key4hep/key4hep-spack) repository, which is required for installation, overriding several packages by the ones customised for Muon Collider simulation studies.
+This repository holds a set of Spack recipes for Muon Collider software (under namespace `mucoll`) based on [Key4hep](https://key4hep.github.io/key4hep-doc/) stack. It is built on top of the key4hep-dev-external environment from the [key4hep-stack](https://github.com/key4hep/key4hep-spack) repository, which is required for installation.
 
 After installing [Spack](https://github.com/key4hep/spack) and downloading the [key4hep-spack](https://github.com/key4hep/key4hep-spack) and [mucoll-spack](https://github.com/MuonColliderSoft/mucoll-spack) repositories, the whole software stack can be installed using the following commands:
 
 ```bash
-# Add repositories
+# Setup spack and install key4hep-externals
 spack repo add ./key4hep-spack
-spack repo add ./mucoll-spack
-
-# Create a Spack environment
-spack env create sim ./mucoll-spack/environments/mucoll-release/spack.yaml
-spack env activate sim
-
-# Install the software stack
-spack add mucoll-stack
+spack env activate ./key4hep-spack/environments/key4hep-dev-external
 spack concretize --reuse
-spack install --fail-fast
+spack install --only-concrete --no-add --fail-fast
+spack env deactivate
+
+# Now move on to mucoll
+spack repo add ./mucoll-spack
+spack env activate ./mucoll-spack/environments/mucoll-release
+spack concretize --reuse
+spack install --only-concrete --no-add --fail-fast
 
 # Load the Muon Collider environment
 source $MUCOLL_STACK
@@ -27,7 +27,7 @@ source $MUCOLL_STACK
 When signing in to a machine with the installed sofware stack (VM or Docker container), it has to be loaded into the environment:
 
 ```bash
-spack env activate sim
+spack env activate ./mucoll-spack/environments/mucoll-release
 source $MUCOLL_STACK
 ```
 
@@ -141,8 +141,5 @@ cd AlmaLinux9
 ./build.sh REPOSITORY VERSION
 ```
 
-Three images are created in sucession:
-
-- `${REPOSITORY}/mucoll-spack:${VERSION}-alma9`: Base OS with developement tools and any Spack installed under `/opt/spack`.
-- `${REPOSITORY}/mucoll-externals:${VERSION}-alma9`: Contains a minimal Spack environment composed of the external packages needed to build the key4hep or mucoll stacks.
+The stack image will be created:
 - `${REPOSITORY}/mucoll-sim:${VERSION}-alma9`: Contains the full Muon Collider Spack environment.


### PR DESCRIPTION
This PR:
- updates the readme to reflect the use of the key4hep-dev-external env
- updates the concretisation checks to use the base images