### PR TITLE
Avoid accidentally leaking github tokens into final images

### DIFF
--- a/Docker/Dockerfile-sim
+++ b/Docker/Dockerfile-sim
@@ -27,9 +27,7 @@ RUN . /opt/setup_spack.sh && \
 # Add the package repositories
 ARG SPACK_BUILDCACHE
 ARG OCI_USERNAME
-RUN --mount=type=secret,id=ocipass \
-    export OCI_PASSWORD=$(cat /run/secrets/ocipass) && \
-    . /opt/setup_spack.sh && \
+RUN . /opt/setup_spack.sh && \
     spack repo add ${SPACK_ROOT}/var/mucoll-spack && \
     if [ -n "${SPACK_BUILDCACHE}" ]; then \
         spack mirror remove local-buildcache || true; \
@@ -48,18 +46,18 @@ RUN . /opt/setup_spack.sh && \
     echo "spack env status" >> ${HOME}/setup_env.sh
 
 # Concretizing the MuColl stack reusing system packages as external
-RUN . ${HOME}/setup_env.sh && \
-    spack concretize --reuse
+RUN --mount=type=secret,id=ocipass \
+    . ${HOME}/setup_env.sh && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack concretize --reuse
 
 # Installing fragments of dependency tree in separate layers for cached debugging
 ENV SPACK_INSTALL_OPTS="--only-concrete --no-add --fail-fast"
 
 RUN --mount=type=secret,id=ocipass \
-    export OCI_PASSWORD=$(cat /run/secrets/ocipass) && \
     . ${HOME}/setup_env.sh && \
     export onnxruntime_ENABLE_AVX512_VNNI=OFF && \
-    spack spec -NIt && \
-    spack install ${SPACK_INSTALL_OPTS} && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack spec -NIt && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack install ${SPACK_INSTALL_OPTS} && \
     spack env deactivate && \
     spack clean -a && \
     spack mirror remove local-buildcache || true


### PR DESCRIPTION
Recoverable via

spack config blame mirrors

Given that the tokens have very limited lifetime actual implications are probably very low, but we should still not leak them

See https://github.com/key4hep/key4hep-spack/pull/792 for more details