### PR TITLE
Pin acts@main to pre-grid-regression commit to unblock build

### DIFF
--- a/environments/mucoll-common/packages.yaml
+++ b/environments/mucoll-common/packages.yaml
@@ -73,7 +73,14 @@ packages:
   # k4actstracking (used by the ml layer) needs the acts GNN plugin (and its
   # py-torch / onnxruntime deps). The sim layer concretizes acts~gnn.
   acts:
-    require: '@main+dd4hep+json cxxstd=20'
+    # Temporarily pin acts@main to the last commit before the grid refactor
+    # (acts-project/acts#5541, c36cd88cd, 2026-06-08) that broke compilation of
+    # the CylindricalSpacePointGrid fill path: grid.atPosition(binIndex) now
+    # resolves to the position-lookup overload (Point = std::size_t), so
+    # MultiAxisHelper subscripts a scalar -> "subscripted value is neither array
+    # nor pointer" when building k4actstracking. Revert to '@main' once acts
+    # main is fixed upstream.
+    require: '@main commit=0f9e9afe70b1e817f965dfda6dc7fa94376fbef6 +dd4hep+json cxxstd=20'
   k4geo:
     require: '@main'
   k4gaudipandora:


### PR DESCRIPTION
Pins `acts@main` to commit `0f9e9afe` (parent of the breaking refactor) to unblock the nightly stack build.

## Problem

The `sim` layer fails to compile `k4actstracking` against current `acts@main` (HEAD `739072bb`):

```
Acts/Utilities/detail/MultiAxisHelper.hpp:192:70: error: subscripted value is neither array nor pointer
  192 |     multiIndex.at(N) = static_cast<std::size_t>(thisAxis.getBin(point[N]));
```

Instantiation chain:
```
CylindricalSpacePointGridCreator::fillGrid
  -> Grid<T,Axes>::atPosition(const Point&)            [Point = std::size_t]   # a global-bin index!
    -> Grid<T,Axes>::localBinsFromPosition(const Point&) [Point = std::size_t]
      -> MultiAxisHelper::getMultiIndexFromPoint -> point[N]                    # subscripts a scalar
```

## Root cause

This is an upstream **acts** regression, not a k4ActsTracking/branch issue (k4actstracking `main` fails identically). In `CylindricalSpacePointGrid.ipp`, acts calls `grid.atPosition(binIndex)` with a `std::size_t` global-bin index; after the 2026-06-08 grid refactor (acts-project/acts#5541, `c36cd88cd`) that resolves to the position-lookup overload, so `MultiAxisHelper` subscripts a scalar.

- Bad: `739072bb` (current acts main HEAD)
- Good: `0f9e9afe` (parent of `c36cd88cd`, 2026-06-08) — pinned here

Verified the deleted buildcache forced a from-source rebuild that still failed, confirming the source (not a stale binary) is the problem.

## Fix

Freeze `acts@main` to `0f9e9afe` in `environments/mucoll-common/packages.yaml`. **Revert to plain `@main` once acts main is fixed upstream** (an issue is being filed at acts-project/acts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)