### PR TITLE
Patch acts@main fillGrid atPosition->at to verify upstream fix

### DIFF
--- a/packages/acts/cylindrical_grid_atposition.patch
+++ b/packages/acts/cylindrical_grid_atposition.patch
@@ -1,0 +1,24 @@
+Fix grid.atPosition(binIndex) -> grid.at(binIndex) in fillGrid.
+
+In CylindricalSpacePointGridCreator::fillGrid the post-fill R-sorting loop
+iterates over *global bin indices* (rBinsIndex holds std::size_t values pushed
+from globalBinFromPosition). The bin must therefore be fetched with the
+global-bin accessor Grid::at(std::size_t) -- exactly as done a few lines above
+(`grid.at(globIndex)`) -- not with Grid::atPosition(const Point&), which is the
+position-lookup overload. Passing a std::size_t to atPosition deduces
+Point = std::size_t and, since acts#5541 routed localBinsFromPosition through
+MultiAxisHelper::getMultiIndexFromPoint, ends up subscripting a scalar
+(`point[N]`), giving "subscripted value is neither array nor pointer" when the
+template is instantiated (e.g. by k4ActsTracking's seeding).
+
+Upstream regression: acts-project/acts#5541 (c36cd88cd). This patch is the
+candidate one-line upstream fix, applied here to verify it unblocks the build.
+--- a/Core/include/Acts/Seeding/detail/CylindricalSpacePointGrid.ipp
++++ b/Core/include/Acts/Seeding/detail/CylindricalSpacePointGrid.ipp
+@@ -209,5 +209,5 @@
+   /// sort SPs in R for each filled bin
+   for (std::size_t binIndex : rBinsIndex) {
+-    auto& rbin = grid.atPosition(binIndex);
++    auto& rbin = grid.at(binIndex);
+     std::ranges::sort(rbin, {}, [](const auto& rb) { return rb->radius(); });
+   }

--- a/packages/acts/package.py
+++ b/packages/acts/package.py
@@ -1,0 +1,30 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.pkg.builtin.acts import Acts as BuiltinActs
+
+from spack.package import *
+
+
+class Acts(BuiltinActs):
+    """Override of the builtin acts package that applies a verification patch
+    for the CylindricalSpacePointGrid fill-path regression on acts@main.
+
+    acts@main currently fails to compile downstream code that instantiates
+    CylindricalSpacePointGridCreator::fillGrid (e.g. k4actstracking seeding):
+    the post-fill sorting loop calls grid.atPosition(binIndex) with a
+    std::size_t global-bin index, which after acts-project/acts#5541 resolves
+    to the position-lookup overload and subscripts a scalar in
+    MultiAxisHelper ("subscripted value is neither array nor pointer").
+
+    The patch changes that call to grid.at(binIndex), matching the global-bin
+    accessor used a few lines above. Remove this override once the fix lands
+    upstream in acts main.
+    """
+
+    patch(
+        "cylindrical_grid_atposition.patch",
+        sha256="4d7c2730148ca629da8d0fb336e21309f8bc117eaf6eeb7086dba25ff03eb5fb",
+        when="@main",
+    )


### PR DESCRIPTION
acts main fails to compile k4actstracking: CylindricalSpacePointGrid.ipp's post-fill sort loop calls grid.atPosition(binIndex) with a std::size_t global bin index. After acts-project/acts#5541 (c36cd88cd) routed localBinsFromPosition through MultiAxisHelper::getMultiIndexFromPoint, that deduces Point=std::size_t and subscripts a scalar -> "subscripted value is neither array nor pointer".

Rather than pinning acts, add a mucoll-namespace acts override that subclasses builtin acts and applies a one-line source patch (atPosition -> at, matching the grid.at(globIndex) accessor used a few lines above) when @main. This keeps acts tracking main while verifying the candidate upstream fix unblocks the build. Remove once the fix lands in acts main.