### PR TITLE
Build analysis-only layer from ubuntu, trim image footprint

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,9 @@
 name: Build MuColl Stack and Publish Image
 description: |
   Publish the layered mucoll software stack docker images:
-  mucoll-analysis -> mucoll-reco -> mucoll-sim -> mucoll-ml.
+  mucoll-analysis -> mucoll-sim -> mucoll-ml.
+  The +sim variant covers both reconstruction and simulation; there is no
+  separate reco image.
   Each layer is built FROM the previous one (per architecture) so packages are
   installed once and reused down the chain. Relies on a spack buildcache.
 
@@ -32,7 +34,7 @@ jobs:
       registry: ghcr.io
       image-type: analysis
       dockerfile: Dockerfile.base
-      spec: mucoll-stack~devtools+pytools+analysis~reco~sim~ml
+      spec: mucoll-stack~devtools+pytools+analysis~sim~ml
 
   analysis-arm64:
     uses: ./.github/workflows/docker-build-push-template.yaml
@@ -43,10 +45,12 @@ jobs:
       registry: ghcr.io
       image-type: analysis
       dockerfile: Dockerfile.base
-      spec: mucoll-stack~devtools+pytools+analysis~reco~sim~ml
+      spec: mucoll-stack~devtools+pytools+analysis~sim~ml
 
-  # -------------------------------------------------------------------- reco --
-  reco-amd64:
+  # --------------------------------------------------------------------- sim --
+  # Built FROM analysis; the +sim variant installs the reconstruction +
+  # simulation packages, so the sim image is the full reco+sim environment.
+  sim-amd64:
     needs: analysis-amd64
     uses: ./.github/workflows/docker-build-push-template.yaml
     with:
@@ -54,12 +58,12 @@ jobs:
       runner: ubuntu-latest
       platform: amd64
       registry: ghcr.io
-      image-type: reco
+      image-type: sim
       dockerfile: Dockerfile.layer
       base-image: ${{ needs.analysis-amd64.outputs.image-uri }}
-      spec: mucoll-stack~devtools+pytools+analysis+reco~sim~ml
+      spec: mucoll-stack~devtools+pytools+analysis+sim~ml
 
-  reco-arm64:
+  sim-arm64:
     needs: analysis-arm64
     uses: ./.github/workflows/docker-build-push-template.yaml
     with:
@@ -67,37 +71,10 @@ jobs:
       runner: ubuntu-24.04-arm
       platform: arm64
       registry: ghcr.io
-      image-type: reco
+      image-type: sim
       dockerfile: Dockerfile.layer
       base-image: ${{ needs.analysis-arm64.outputs.image-uri }}
-      spec: mucoll-stack~devtools+pytools+analysis+reco~sim~ml
-
-  # --------------------------------------------------------------------- sim --
-  sim-amd64:
-    needs: reco-amd64
-    uses: ./.github/workflows/docker-build-push-template.yaml
-    with:
-      os: ubuntu24
-      runner: ubuntu-latest
-      platform: amd64
-      registry: ghcr.io
-      image-type: sim
-      dockerfile: Dockerfile.layer
-      base-image: ${{ needs.reco-amd64.outputs.image-uri }}
-      spec: mucoll-stack~devtools+pytools+analysis+reco+sim~ml
-
-  sim-arm64:
-    needs: reco-arm64
-    uses: ./.github/workflows/docker-build-push-template.yaml
-    with:
-      os: ubuntu24
-      runner: ubuntu-24.04-arm
-      platform: arm64
-      registry: ghcr.io
-      image-type: sim
-      dockerfile: Dockerfile.layer
-      base-image: ${{ needs.reco-arm64.outputs.image-uri }}
-      spec: mucoll-stack~devtools+pytools+analysis+reco+sim~ml
+      spec: mucoll-stack~devtools+pytools+analysis+sim~ml
 
   # ---------------------------------------------------------------------- ml --
   ml-amd64:
@@ -111,7 +88,7 @@ jobs:
       image-type: ml
       dockerfile: Dockerfile.layer
       base-image: ${{ needs.sim-amd64.outputs.image-uri }}
-      spec: mucoll-stack~devtools+pytools+analysis+reco+sim+ml
+      spec: mucoll-stack~devtools+pytools+analysis+sim+ml
 
   ml-arm64:
     needs: sim-arm64
@@ -124,7 +101,7 @@ jobs:
       image-type: ml
       dockerfile: Dockerfile.layer
       base-image: ${{ needs.sim-arm64.outputs.image-uri }}
-      spec: mucoll-stack~devtools+pytools+analysis+reco+sim+ml
+      spec: mucoll-stack~devtools+pytools+analysis+sim+ml
 
   # --------------------------------------------------------------- manifests --
   manifest-analysis:
@@ -136,16 +113,6 @@ jobs:
       image-type: analysis
       amd64-image: ${{ needs.analysis-amd64.outputs.image-uri }}
       arm64-image: ${{ needs.analysis-arm64.outputs.image-uri }}
-
-  manifest-reco:
-    needs: [reco-amd64, reco-arm64]
-    uses: ./.github/workflows/manifest-template.yaml
-    with:
-      os: ubuntu24
-      registry: ghcr.io
-      image-type: reco
-      amd64-image: ${{ needs.reco-amd64.outputs.image-uri }}
-      arm64-image: ${{ needs.reco-arm64.outputs.image-uri }}
 
   manifest-sim:
     needs: [sim-amd64, sim-arm64]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
       registry: ghcr.io
       image-type: analysis
       dockerfile: Dockerfile.base
-      spec: mucoll-stack+devtools+pytools+analysis~reco~sim~ml
+      spec: mucoll-stack~devtools+pytools+analysis~reco~sim~ml
 
   analysis-arm64:
     uses: ./.github/workflows/docker-build-push-template.yaml
@@ -43,7 +43,7 @@ jobs:
       registry: ghcr.io
       image-type: analysis
       dockerfile: Dockerfile.base
-      spec: mucoll-stack+devtools+pytools+analysis~reco~sim~ml
+      spec: mucoll-stack~devtools+pytools+analysis~reco~sim~ml
 
   # -------------------------------------------------------------------- reco --
   reco-amd64:
@@ -57,7 +57,7 @@ jobs:
       image-type: reco
       dockerfile: Dockerfile.layer
       base-image: ${{ needs.analysis-amd64.outputs.image-uri }}
-      spec: mucoll-stack+devtools+pytools+analysis+reco~sim~ml
+      spec: mucoll-stack~devtools+pytools+analysis+reco~sim~ml
 
   reco-arm64:
     needs: analysis-arm64
@@ -70,7 +70,7 @@ jobs:
       image-type: reco
       dockerfile: Dockerfile.layer
       base-image: ${{ needs.analysis-arm64.outputs.image-uri }}
-      spec: mucoll-stack+devtools+pytools+analysis+reco~sim~ml
+      spec: mucoll-stack~devtools+pytools+analysis+reco~sim~ml
 
   # --------------------------------------------------------------------- sim --
   sim-amd64:
@@ -84,7 +84,7 @@ jobs:
       image-type: sim
       dockerfile: Dockerfile.layer
       base-image: ${{ needs.reco-amd64.outputs.image-uri }}
-      spec: mucoll-stack+devtools+pytools+analysis+reco+sim~ml
+      spec: mucoll-stack~devtools+pytools+analysis+reco+sim~ml
 
   sim-arm64:
     needs: reco-arm64
@@ -97,7 +97,7 @@ jobs:
       image-type: sim
       dockerfile: Dockerfile.layer
       base-image: ${{ needs.reco-arm64.outputs.image-uri }}
-      spec: mucoll-stack+devtools+pytools+analysis+reco+sim~ml
+      spec: mucoll-stack~devtools+pytools+analysis+reco+sim~ml
 
   # ---------------------------------------------------------------------- ml --
   ml-amd64:
@@ -111,7 +111,7 @@ jobs:
       image-type: ml
       dockerfile: Dockerfile.layer
       base-image: ${{ needs.sim-amd64.outputs.image-uri }}
-      spec: mucoll-stack+devtools+pytools+analysis+reco+sim+ml
+      spec: mucoll-stack~devtools+pytools+analysis+reco+sim+ml
 
   ml-arm64:
     needs: sim-arm64
@@ -124,7 +124,7 @@ jobs:
       image-type: ml
       dockerfile: Dockerfile.layer
       base-image: ${{ needs.sim-arm64.outputs.image-uri }}
-      spec: mucoll-stack+devtools+pytools+analysis+reco+sim+ml
+      spec: mucoll-stack~devtools+pytools+analysis+reco+sim+ml
 
   # --------------------------------------------------------------- manifests --
   manifest-analysis:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: Build MuColl Stack and Publish Image
 description: |
   Publish the layered mucoll software stack docker images:
-  mucoll-analysis -> mucoll-sim -> mucoll-ml.
+  mucoll-analysis -> mucoll-reco -> mucoll-sim -> mucoll-ml.
   Each layer is built FROM the previous one (per architecture) so packages are
   installed once and reused down the chain. Relies on a spack buildcache.
 
@@ -32,7 +32,7 @@ jobs:
       registry: ghcr.io
       image-type: analysis
       dockerfile: Dockerfile.base
-      spec: mucoll-stack+devtools+pytools+analysis~sim~ml
+      spec: mucoll-stack+devtools+pytools+analysis~reco~sim~ml
 
   analysis-arm64:
     uses: ./.github/workflows/docker-build-push-template.yaml
@@ -43,11 +43,38 @@ jobs:
       registry: ghcr.io
       image-type: analysis
       dockerfile: Dockerfile.base
-      spec: mucoll-stack+devtools+pytools+analysis~sim~ml
+      spec: mucoll-stack+devtools+pytools+analysis~reco~sim~ml
+
+  # -------------------------------------------------------------------- reco --
+  reco-amd64:
+    needs: analysis-amd64
+    uses: ./.github/workflows/docker-build-push-template.yaml
+    with:
+      os: ubuntu24
+      runner: ubuntu-latest
+      platform: amd64
+      registry: ghcr.io
+      image-type: reco
+      dockerfile: Dockerfile.layer
+      base-image: ${{ needs.analysis-amd64.outputs.image-uri }}
+      spec: mucoll-stack+devtools+pytools+analysis+reco~sim~ml
+
+  reco-arm64:
+    needs: analysis-arm64
+    uses: ./.github/workflows/docker-build-push-template.yaml
+    with:
+      os: ubuntu24
+      runner: ubuntu-24.04-arm
+      platform: arm64
+      registry: ghcr.io
+      image-type: reco
+      dockerfile: Dockerfile.layer
+      base-image: ${{ needs.analysis-arm64.outputs.image-uri }}
+      spec: mucoll-stack+devtools+pytools+analysis+reco~sim~ml
 
   # --------------------------------------------------------------------- sim --
   sim-amd64:
-    needs: analysis-amd64
+    needs: reco-amd64
     uses: ./.github/workflows/docker-build-push-template.yaml
     with:
       os: ubuntu24
@@ -56,11 +83,11 @@ jobs:
       registry: ghcr.io
       image-type: sim
       dockerfile: Dockerfile.layer
-      base-image: ${{ needs.analysis-amd64.outputs.image-uri }}
-      spec: mucoll-stack+devtools+pytools+analysis+sim~ml
+      base-image: ${{ needs.reco-amd64.outputs.image-uri }}
+      spec: mucoll-stack+devtools+pytools+analysis+reco+sim~ml
 
   sim-arm64:
-    needs: analysis-arm64
+    needs: reco-arm64
     uses: ./.github/workflows/docker-build-push-template.yaml
     with:
       os: ubuntu24
@@ -69,8 +96,8 @@ jobs:
       registry: ghcr.io
       image-type: sim
       dockerfile: Dockerfile.layer
-      base-image: ${{ needs.analysis-arm64.outputs.image-uri }}
-      spec: mucoll-stack+devtools+pytools+analysis+sim~ml
+      base-image: ${{ needs.reco-arm64.outputs.image-uri }}
+      spec: mucoll-stack+devtools+pytools+analysis+reco+sim~ml
 
   # ---------------------------------------------------------------------- ml --
   ml-amd64:
@@ -84,7 +111,7 @@ jobs:
       image-type: ml
       dockerfile: Dockerfile.layer
       base-image: ${{ needs.sim-amd64.outputs.image-uri }}
-      spec: mucoll-stack+devtools+pytools+analysis+sim+ml
+      spec: mucoll-stack+devtools+pytools+analysis+reco+sim+ml
 
   ml-arm64:
     needs: sim-arm64
@@ -97,7 +124,7 @@ jobs:
       image-type: ml
       dockerfile: Dockerfile.layer
       base-image: ${{ needs.sim-arm64.outputs.image-uri }}
-      spec: mucoll-stack+devtools+pytools+analysis+sim+ml
+      spec: mucoll-stack+devtools+pytools+analysis+reco+sim+ml
 
   # --------------------------------------------------------------- manifests --
   manifest-analysis:
@@ -109,6 +136,16 @@ jobs:
       image-type: analysis
       amd64-image: ${{ needs.analysis-amd64.outputs.image-uri }}
       arm64-image: ${{ needs.analysis-arm64.outputs.image-uri }}
+
+  manifest-reco:
+    needs: [reco-amd64, reco-arm64]
+    uses: ./.github/workflows/manifest-template.yaml
+    with:
+      os: ubuntu24
+      registry: ghcr.io
+      image-type: reco
+      amd64-image: ${{ needs.reco-amd64.outputs.image-uri }}
+      arm64-image: ${{ needs.reco-arm64.outputs.image-uri }}
 
   manifest-sim:
     needs: [sim-amd64, sim-arm64]

--- a/.github/workflows/docker-build-push-template.yaml
+++ b/.github/workflows/docker-build-push-template.yaml
@@ -78,6 +78,19 @@ jobs:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve spack pins from key4hep-spack
+        # Resolve the key4hep-spack main SHA once and read both pin files *at
+        # that SHA*, so the spack commit, the spack-packages commit and the
+        # key4hep-spack checkout (whose .cherry-pick targets that spack-packages
+        # commit) stay mutually consistent within a run. Only Dockerfile.base
+        # consumes these; the layer Dockerfile ignores the unused build-args.
+        id: pins
+        run: |
+          k4sha=$(git ls-remote https://github.com/key4hep/key4hep-spack.git main | cut -f1)
+          echo "k4sha=$k4sha" >> "$GITHUB_OUTPUT"
+          base="https://raw.githubusercontent.com/key4hep/key4hep-spack/$k4sha"
+          echo "spack=$(curl -fsSL "$base/.latest-commit" | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+          echo "packages=$(curl -fsSL "$base/.latest-packages-commit" | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
       - name: Docker Meta
         id: meta
         uses: docker/metadata-action@v6
@@ -104,6 +117,9 @@ jobs:
             SPACK_BUILDCACHE=oci://ghcr.io/${{ github.repository_owner }}/mucoll-buildcache
             OCI_USERNAME=${{ github.actor }}
             BRANCH=${{ github.ref_name }}
+            SPACK_COMMIT=${{ steps.pins.outputs.spack }}
+            SPACK_PACKAGES_COMMIT=${{ steps.pins.outputs.packages }}
+            KEY4HEP_SPACK_SHA=${{ steps.pins.outputs.k4sha }}
           secrets: |
             "ocipass=${{ secrets.GITHUB_TOKEN }}"
           tags: ${{ steps.meta.outputs.tags }}

--- a/Docker/Dockerfile.base
+++ b/Docker/Dockerfile.base
@@ -162,7 +162,7 @@ RUN --mount=type=secret,id=ocipass \
 # Point the default setup at this layer's mucoll-stack root. Only the analysis
 # root is installed in this image, so the spack find query is unambiguous.
 RUN . ${HOME}/setup_env.sh && \
-    MUCOLL_STACK_PATH=$(spack find --format "{prefix}" mucoll-stack+devtools+pytools+analysis~reco~sim~ml) && \
+    MUCOLL_STACK_PATH=$(spack find --format "{prefix}" mucoll-stack~devtools+pytools+analysis~reco~sim~ml) && \
     MUCOLL_STACK_PATH_CLEANED=$(echo ${MUCOLL_STACK_PATH} | sed -E 's/\x1b\[[0-9;]*m//g') && \
     echo "source ${MUCOLL_STACK_PATH_CLEANED}/setup.sh" > /opt/setup_mucoll.sh && \
     echo "alias setup_mucoll=\". ${MUCOLL_STACK_PATH_CLEANED}/setup.sh\"" >> /etc/profile.d/aliases.sh

--- a/Docker/Dockerfile.base
+++ b/Docker/Dockerfile.base
@@ -2,17 +2,89 @@
 #  Repository: ${IMAGE}/mucoll-analysis
 #  Tag:        ${VERSION}-${OS}
 #
-#  Base layer of the layered Muon Collider images. It bootstraps spack, the
-#  mucoll repo and the toolchain, concretizes the WHOLE layered environment
-#  (analysis + sim + ml roots together, so shared packages get a single hash)
-#  but installs ONLY the analysis root. The mucoll-sim / mucoll-ml images are
-#  built FROM this image with Dockerfile.layer and install their extra specs,
-#  reusing this layer's already-installed store.
+#  Base layer of the layered Muon Collider images. Starting from a plain
+#  ubuntu:24.04 it bootstraps spack + spack-packages + key4hep-spack from
+#  scratch (the relevant steps of key4hep-images/ubuntu24-build and
+#  key4hep-spack/Dockerfile-externals), then clones the mucoll repo and the
+#  toolchain, concretizes the WHOLE layered environment (analysis + reco + sim +
+#  ml roots together, so shared packages get a single hash) but installs ONLY
+#  the analysis root. The mucoll-reco / mucoll-sim / mucoll-ml images are built
+#  FROM this image with Dockerfile.layer and install their extra specs, reusing
+#  this layer's already-installed store.
 ###############################################################################
 
-ARG OS=alma9
-FROM ghcr.io/key4hep/key4hep-externals-${OS}:2026-05-13
+ARG OS=ubuntu24
+FROM ubuntu:24.04
 
+# --------------------------------------------------------------------------- #
+#  System packages (from key4hep-images/ubuntu24/ubuntu24-build/Dockerfile).
+#  tzdata is needed for setting the timezones (gives the nightlies the right
+#  time and date).
+# --------------------------------------------------------------------------- #
+RUN apt update -y && \
+    apt upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt install -y \
+    build-essential git python3 python3-pip vim unzip gfortran file curl wget pkg-config rsync tzdata libgl1-mesa-dev libglu1-mesa libglu1-mesa-dev libkrb5-dev ccache mold strace \
+    python3-boto3 python3-requests python3-yaml && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# --------------------------------------------------------------------------- #
+#  Bootstrap spack + spack-packages (from key4hep-spack/Dockerfile-externals).
+#  Pins are supplied at build time by CI, resolved from the key4hep-spack repo:
+#    SPACK_COMMIT          <- key4hep-spack/.latest-commit
+#    SPACK_PACKAGES_COMMIT <- key4hep-spack/.latest-packages-commit
+#    KEY4HEP_SPACK_SHA     <- key4hep-spack main HEAD (the SHA the pins were read from)
+# --------------------------------------------------------------------------- #
+ENV SPACK_COLOR="always"
+ARG SPACK_COMMIT
+ARG SPACK_PACKAGES_COMMIT
+
+# Setting up Spack
+RUN git clone https://github.com/spack/spack.git /opt/spack && \
+    echo "export SPACK_ROOT=/opt/spack" >> /opt/setup_spack.sh && \
+    echo ". /opt/spack/share/spack/setup-env.sh" >> /opt/setup_spack.sh && \
+    echo "alias setup_spack=\". /opt/setup_spack.sh\"" >> /etc/profile.d/aliases.sh && \
+    if [ -n "${SPACK_COMMIT}" ]; then cd /opt/spack && git checkout ${SPACK_COMMIT}; fi
+
+# Checkout spack packages and register them as the builtin repo
+RUN . /opt/setup_spack.sh && \
+    git clone https://github.com/spack/spack-packages /opt/spack-packages && \
+    cd /opt/spack-packages && \
+    if [ -n "${SPACK_PACKAGES_COMMIT}" ]; then git checkout ${SPACK_PACKAGES_COMMIT}; fi && \
+    spack repo set --destination "/opt/spack-packages" builtin
+
+# Configure spack: padded install paths (buildcache relocation) and system compilers
+RUN . /opt/setup_spack.sh && \
+    spack config add 'config:install_tree:padded_length:128' && \
+    spack compiler find
+
+# --------------------------------------------------------------------------- #
+#  Add the key4hep-spack repository (the `k4` namespace mucoll-stack imports
+#  from, and where most externals / key4hep packages are defined). Previously
+#  this was provided by the key4hep-externals base image; built from ubuntu we
+#  must clone it, apply its cherry-picks to spack-packages, and add the repo.
+# --------------------------------------------------------------------------- #
+ARG KEY4HEP_SPACK_REPO=key4hep/key4hep-spack
+ARG KEY4HEP_SPACK_SHA
+RUN . /opt/setup_spack.sh && \
+    REPOPATH=${SPACK_ROOT}/var/key4hep-spack && \
+    git clone https://github.com/${KEY4HEP_SPACK_REPO} ${REPOPATH} && \
+    cd ${REPOPATH} && \
+    if [ -n "${KEY4HEP_SPACK_SHA}" ]; then git checkout ${KEY4HEP_SPACK_SHA}; fi
+
+# Apply key4hep's patches to spack packages, then register the repo
+RUN . /opt/setup_spack.sh && \
+    REPOPATH=${SPACK_ROOT}/var/key4hep-spack && \
+    cd /opt/spack-packages && \
+    . ${REPOPATH}/.cherry-pick
+RUN . /opt/setup_spack.sh && \
+    spack repo add ${SPACK_ROOT}/var/key4hep-spack
+
+# --------------------------------------------------------------------------- #
+#  MuColl-specific bootstrap (unchanged: assumes /opt/setup_spack.sh, /opt/spack
+#  and /opt/spack-packages exist, which the steps above now provide).
+# --------------------------------------------------------------------------- #
 ARG MUCOLL_SHA=e49a0639ff987a84fa0c6263e068776f9d7b6f67
 ARG GITHUB_REPOSITORY=muoncollidersoft/mucoll-spack
 
@@ -23,7 +95,7 @@ RUN . /opt/setup_spack.sh && \
     cd ${REPOPATH} && \
     git checkout ${MUCOLL_SHA}
 
-# Apply our patches to spack
+# Apply our patches to spack (after key4hep's: overrides py-numba/py-llvmlite for LLVM 20)
 RUN . /opt/setup_spack.sh && \
     REPOPATH=${SPACK_ROOT}/var/mucoll-spack && \
     cd /opt/spack-packages && \
@@ -53,7 +125,7 @@ RUN . /opt/setup_spack.sh && \
         spack mirror add --oci-username "${OCI_USERNAME}" --oci-password-variable OCI_PASSWORD --unsigned --autopush local-buildcache "${SPACK_BUILDCACHE}";\
     fi
 
-# Activate the layered environment (analysis + sim + ml roots)
+# Activate the layered environment (analysis + reco + sim + ml roots)
 ARG ENVIRONMENT=mucoll-layered
 RUN . /opt/setup_spack.sh && \
     cd ${SPACK_ROOT}/var/mucoll-spack/environments/${ENVIRONMENT} && \
@@ -65,7 +137,7 @@ RUN . /opt/setup_spack.sh && \
     echo "cd -" >> ${HOME}/setup_env.sh && \
     echo "spack env status" >> ${HOME}/setup_env.sh
 
-# Concretize the WHOLE layered stack (all three roots) reusing system packages
+# Concretize the WHOLE layered stack (all four roots) reusing system packages
 # as external, so shared dependencies get identical hashes across all layers.
 RUN --mount=type=secret,id=ocipass \
     . ${HOME}/setup_env.sh && \
@@ -78,9 +150,9 @@ RUN --mount=type=secret,id=ocipass \
 ENV SPACK_INSTALL_OPTS="--only-concrete --no-add --fail-fast"
 
 # Install ONLY the analysis root from the already-concretized environment.
-# The ~sim~ml negations are required so the abstract spec matches just the
-# analysis root and not the sim/ml roots (which also satisfy +analysis).
-ARG SPEC=mucoll-stack+devtools+pytools+analysis~sim~ml
+# The ~reco~sim~ml negations are required so the abstract spec matches just the
+# analysis root and not the reco/sim/ml roots (which also satisfy +analysis).
+ARG SPEC=mucoll-stack+devtools+pytools+analysis~reco~sim~ml
 RUN --mount=type=secret,id=ocipass \
     . ${HOME}/setup_env.sh && \
     OCI_PASSWORD=$(cat /run/secrets/ocipass) spack spec -NIt "${SPEC}" && \
@@ -92,7 +164,7 @@ RUN --mount=type=secret,id=ocipass \
 # Point the default setup at this layer's mucoll-stack root. Only the analysis
 # root is installed in this image, so the spack find query is unambiguous.
 RUN . ${HOME}/setup_env.sh && \
-    MUCOLL_STACK_PATH=$(spack find --format "{prefix}" mucoll-stack+devtools+pytools+analysis~sim~ml) && \
+    MUCOLL_STACK_PATH=$(spack find --format "{prefix}" mucoll-stack+devtools+pytools+analysis~reco~sim~ml) && \
     MUCOLL_STACK_PATH_CLEANED=$(echo ${MUCOLL_STACK_PATH} | sed -E 's/\x1b\[[0-9;]*m//g') && \
     echo "source ${MUCOLL_STACK_PATH_CLEANED}/setup.sh" > /opt/setup_mucoll.sh && \
     echo "alias setup_mucoll=\". ${MUCOLL_STACK_PATH_CLEANED}/setup.sh\"" >> /etc/profile.d/aliases.sh

--- a/Docker/Dockerfile.base
+++ b/Docker/Dockerfile.base
@@ -149,7 +149,7 @@ RUN --mount=type=secret,id=ocipass \
     . ${HOME}/setup_env.sh && \
     export PATH=/usr/lib/llvm-20/bin:${PATH} && \
     spack compiler find /usr/lib/llvm-20/bin && \
-    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack external find rust --not-buildable && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack external find --not-buildable && \
     OCI_PASSWORD=$(cat /run/secrets/ocipass) spack concretize --reuse
 
 # Install fragments of the dependency tree in separate layers for cached debugging
@@ -164,6 +164,7 @@ RUN --mount=type=secret,id=ocipass \
     OCI_PASSWORD=$(cat /run/secrets/ocipass) spack spec -NIt "${SPEC}" && \
     OCI_PASSWORD=$(cat /run/secrets/ocipass) spack install ${SPACK_INSTALL_OPTS} "${SPEC}" && \
     spack env deactivate && \
+    spack gc -y && \
     spack clean -a && \
     { spack mirror remove local-buildcache || true; }
 

--- a/Docker/Dockerfile.base
+++ b/Docker/Dockerfile.base
@@ -150,7 +150,7 @@ ENV SPACK_INSTALL_OPTS="--only-concrete --no-add --fail-fast"
 # Install ONLY the analysis root from the already-concretized environment.
 # The ~reco~sim~ml negations are required so the abstract spec matches just the
 # analysis root and not the reco/sim/ml roots (which also satisfy +analysis).
-ARG SPEC=mucoll-stack+devtools+pytools+analysis~reco~sim~ml
+ARG SPEC=mucoll-stack~devtools+pytools+analysis~reco~sim~ml
 RUN --mount=type=secret,id=ocipass \
     . ${HOME}/setup_env.sh && \
     OCI_PASSWORD=$(cat /run/secrets/ocipass) spack spec -NIt "${SPEC}" && \

--- a/Docker/Dockerfile.base
+++ b/Docker/Dockerfile.base
@@ -33,7 +33,7 @@ RUN apt update && apt install -y wget gnupg && \
 RUN apt update -y && apt upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt install -y \
     build-essential git python3 python3-pip vim unzip gfortran file curl wget pkg-config rsync tzdata libgl1-mesa-dev libglu1-mesa libglu1-mesa-dev libkrb5-dev ccache mold strace \
-    python3-boto3 python3-requests python3-yaml llvm-20 clang-20 lld-20 libzstd-dev zlib1g-dev && \
+    python3-boto3 python3-requests python3-yaml llvm-20 clang-20 lld-20 libzstd-dev zlib1g-dev libssl-dev libcurl4-openssl-dev && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -137,11 +137,19 @@ RUN . /opt/setup_spack.sh && \
 
 # Concretize the WHOLE layered stack (all four roots) reusing system packages
 # as external, so shared dependencies get identical hashes across all layers.
+#
+# Only `rust` is detected as an external here (it is installed via rustup, not
+# apt). A blanket `spack external find --not-buildable` must NOT be used on this
+# minimal base: it picks up the system openssl/curl, which ship only as runtime
+# libraries + CLIs (no -dev headers), and marking them non-buildable then breaks
+# anything that compiles against them (e.g. libevent: "openssl/ssl.h not found").
+# The genuinely-wanted externals (opengl, mesa, krb5, openssh, llvm) are declared
+# explicitly in environments/mucoll-common/packages.yaml instead.
 RUN --mount=type=secret,id=ocipass \
     . ${HOME}/setup_env.sh && \
     export PATH=/usr/lib/llvm-20/bin:${PATH} && \
     spack compiler find /usr/lib/llvm-20/bin && \
-    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack external find --not-buildable && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack external find rust --not-buildable && \
     OCI_PASSWORD=$(cat /run/secrets/ocipass) spack concretize --reuse
 
 # Install fragments of the dependency tree in separate layers for cached debugging

--- a/Docker/Dockerfile.base
+++ b/Docker/Dockerfile.base
@@ -21,13 +21,25 @@ FROM ubuntu:24.04
 #  tzdata is needed for setting the timezones (gives the nightlies the right
 #  time and date).
 # --------------------------------------------------------------------------- #
-RUN apt update -y && \
-    apt upgrade -y && \
+RUN apt update && apt install -y wget gnupg && \
+    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
+    echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" | tee /etc/apt/sources.list.d/llvm-20.list
+
+# Install pre-compiled LLVM binaries to avoid expensive source builds in CI.
+# libzstd-dev/zlib1g-dev are needed so LLVM's CMake exports (LLVMSupport ->
+# zstd::libzstd_shared, ZLIB::ZLIB) resolve when py-llvmlite links against LLVM.
+# Add the LLVM apt repo (if not already added)
+
+RUN apt update -y && apt upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt install -y \
     build-essential git python3 python3-pip vim unzip gfortran file curl wget pkg-config rsync tzdata libgl1-mesa-dev libglu1-mesa libglu1-mesa-dev libkrb5-dev ccache mold strace \
-    python3-boto3 python3-requests python3-yaml && \
+    python3-boto3 python3-requests python3-yaml llvm-20 clang-20 lld-20 libzstd-dev zlib1g-dev && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
+
+# Get Rust
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y && \
+    echo ". $HOME/.cargo/env" > ${HOME}/setup_env.sh
 
 # --------------------------------------------------------------------------- #
 #  Bootstrap spack + spack-packages (from key4hep-spack/Dockerfile-externals).
@@ -78,6 +90,7 @@ RUN . /opt/setup_spack.sh && \
     REPOPATH=${SPACK_ROOT}/var/key4hep-spack && \
     cd /opt/spack-packages && \
     . ${REPOPATH}/.cherry-pick
+
 RUN . /opt/setup_spack.sh && \
     spack repo add ${SPACK_ROOT}/var/key4hep-spack
 
@@ -100,21 +113,6 @@ RUN . /opt/setup_spack.sh && \
     REPOPATH=${SPACK_ROOT}/var/mucoll-spack && \
     cd /opt/spack-packages && \
     . ${REPOPATH}/.cherry-pick
-
-# Get Rust
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y && \
-    echo ". $HOME/.cargo/env" > ${HOME}/setup_env.sh
-
-# Install pre-compiled LLVM binaries to avoid expensive source builds in CI.
-# libzstd-dev/zlib1g-dev are needed so LLVM's CMake exports (LLVMSupport ->
-# zstd::libzstd_shared, ZLIB::ZLIB) resolve when py-llvmlite links against LLVM.
-# Add the LLVM apt repo (if not already added)
-RUN apt update && apt install -y wget gnupg && \
-    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
-    echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" | tee /etc/apt/sources.list.d/llvm-20.list && \
-    apt update && \
-    apt install -y llvm-20 clang-20 lld-20 libzstd-dev zlib1g-dev && \
-    llvm-config-20 --version
 
 # Add the package repositories
 ARG SPACK_BUILDCACHE

--- a/Docker/Dockerfile.base
+++ b/Docker/Dockerfile.base
@@ -28,7 +28,6 @@ RUN apt update && apt install -y wget && \
 # Install pre-compiled LLVM binaries to avoid expensive source builds in CI.
 # libzstd-dev/zlib1g-dev are needed so LLVM's CMake exports (LLVMSupport ->
 # zstd::libzstd_shared, ZLIB::ZLIB) resolve when py-llvmlite links against LLVM.
-# Add the LLVM apt repo (if not already added)
 
 RUN apt update -y && apt upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt install -y \

--- a/Docker/Dockerfile.base
+++ b/Docker/Dockerfile.base
@@ -17,9 +17,7 @@ ARG OS=ubuntu24
 FROM ubuntu:24.04
 
 # --------------------------------------------------------------------------- #
-#  System packages (from key4hep-images/ubuntu24/ubuntu24-build/Dockerfile).
-#  tzdata is needed for setting the timezones (gives the nightlies the right
-#  time and date).
+#  System packages 
 # --------------------------------------------------------------------------- #
 RUN apt update && apt install -y wget && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
@@ -72,9 +70,7 @@ RUN . /opt/setup_spack.sh && \
 
 # --------------------------------------------------------------------------- #
 #  Add the key4hep-spack repository (the `k4` namespace mucoll-stack imports
-#  from, and where most externals / key4hep packages are defined). Previously
-#  this was provided by the key4hep-externals base image; built from ubuntu we
-#  must clone it, apply its cherry-picks to spack-packages, and add the repo.
+#  from, and where most externals / key4hep packages are defined). 
 # --------------------------------------------------------------------------- #
 ARG KEY4HEP_SPACK_REPO=key4hep/key4hep-spack
 ARG KEY4HEP_SPACK_SHA
@@ -94,8 +90,7 @@ RUN . /opt/setup_spack.sh && \
     spack repo add ${SPACK_ROOT}/var/key4hep-spack
 
 # --------------------------------------------------------------------------- #
-#  MuColl-specific bootstrap (unchanged: assumes /opt/setup_spack.sh, /opt/spack
-#  and /opt/spack-packages exist, which the steps above now provide).
+#  MuColl-specific bootstrap 
 # --------------------------------------------------------------------------- #
 ARG MUCOLL_SHA=e49a0639ff987a84fa0c6263e068776f9d7b6f67
 ARG GITHUB_REPOSITORY=muoncollidersoft/mucoll-spack

--- a/Docker/Dockerfile.base
+++ b/Docker/Dockerfile.base
@@ -141,7 +141,7 @@ RUN --mount=type=secret,id=ocipass \
     . ${HOME}/setup_env.sh && \
     export PATH=/usr/lib/llvm-20/bin:${PATH} && \
     spack compiler find /usr/lib/llvm-20/bin && \
-    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack external find rust --not-buildable && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack external find --not-buildable && \
     OCI_PASSWORD=$(cat /run/secrets/ocipass) spack concretize --reuse
 
 # Install fragments of the dependency tree in separate layers for cached debugging

--- a/Docker/Dockerfile.base
+++ b/Docker/Dockerfile.base
@@ -21,7 +21,7 @@ FROM ubuntu:24.04
 #  tzdata is needed for setting the timezones (gives the nightlies the right
 #  time and date).
 # --------------------------------------------------------------------------- #
-RUN apt update && apt install -y wget gnupg && \
+RUN apt update && apt install -y wget && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
     echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" | tee /etc/apt/sources.list.d/llvm-20.list
 
@@ -32,8 +32,8 @@ RUN apt update && apt install -y wget gnupg && \
 
 RUN apt update -y && apt upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt install -y \
-    build-essential git python3 python3-pip vim unzip gfortran file curl wget pkg-config rsync tzdata libgl1-mesa-dev libglu1-mesa libglu1-mesa-dev libkrb5-dev ccache mold strace \
-    python3-boto3 python3-requests python3-yaml llvm-20 clang-20 lld-20 libzstd-dev zlib1g-dev libssl-dev libcurl4-openssl-dev && \
+    build-essential git python3 unzip gfortran file curl wget pkg-config rsync tzdata libgl1-mesa-dev libglu1-mesa libglu1-mesa-dev libkrb5-dev \
+    llvm-20 clang-20 lld-20 libzstd-dev zlib1g-dev && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -149,7 +149,7 @@ RUN --mount=type=secret,id=ocipass \
     . ${HOME}/setup_env.sh && \
     export PATH=/usr/lib/llvm-20/bin:${PATH} && \
     spack compiler find /usr/lib/llvm-20/bin && \
-    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack external find --not-buildable && \
+    OCI_PASSWORD=$(cat /run/secrets/ocipass) spack external find rust --not-buildable && \
     OCI_PASSWORD=$(cat /run/secrets/ocipass) spack concretize --reuse
 
 # Install fragments of the dependency tree in separate layers for cached debugging

--- a/Docker/Dockerfile.base
+++ b/Docker/Dockerfile.base
@@ -6,11 +6,11 @@
 #  ubuntu:24.04 it bootstraps spack + spack-packages + key4hep-spack from
 #  scratch (the relevant steps of key4hep-images/ubuntu24-build and
 #  key4hep-spack/Dockerfile-externals), then clones the mucoll repo and the
-#  toolchain, concretizes the WHOLE layered environment (analysis + reco + sim +
-#  ml roots together, so shared packages get a single hash) but installs ONLY
-#  the analysis root. The mucoll-reco / mucoll-sim / mucoll-ml images are built
-#  FROM this image with Dockerfile.layer and install their extra specs, reusing
-#  this layer's already-installed store.
+#  toolchain, concretizes the WHOLE layered environment (analysis + sim + ml
+#  roots together, so shared packages get a single hash) but installs ONLY
+#  the analysis root. The mucoll-sim / mucoll-ml images are built FROM this
+#  image with Dockerfile.layer and install their extra specs, reusing this
+#  layer's already-installed store.
 ###############################################################################
 
 ARG OS=ubuntu24
@@ -122,7 +122,7 @@ RUN . /opt/setup_spack.sh && \
         spack mirror add --oci-username "${OCI_USERNAME}" --oci-password-variable OCI_PASSWORD --unsigned --autopush local-buildcache "${SPACK_BUILDCACHE}";\
     fi
 
-# Activate the layered environment (analysis + reco + sim + ml roots)
+# Activate the layered environment (analysis + sim + ml roots)
 ARG ENVIRONMENT=mucoll-layered
 RUN . /opt/setup_spack.sh && \
     cd ${SPACK_ROOT}/var/mucoll-spack/environments/${ENVIRONMENT} && \
@@ -155,9 +155,9 @@ RUN --mount=type=secret,id=ocipass \
 ENV SPACK_INSTALL_OPTS="--only-concrete --no-add --fail-fast"
 
 # Install ONLY the analysis root from the already-concretized environment.
-# The ~reco~sim~ml negations are required so the abstract spec matches just the
-# analysis root and not the reco/sim/ml roots (which also satisfy +analysis).
-ARG SPEC=mucoll-stack~devtools+pytools+analysis~reco~sim~ml
+# The ~sim~ml negations are required so the abstract spec matches just the
+# analysis root and not the sim/ml roots (which also satisfy +analysis).
+ARG SPEC=mucoll-stack~devtools+pytools+analysis~sim~ml
 RUN --mount=type=secret,id=ocipass \
     . ${HOME}/setup_env.sh && \
     OCI_PASSWORD=$(cat /run/secrets/ocipass) spack spec -NIt "${SPEC}" && \
@@ -170,7 +170,7 @@ RUN --mount=type=secret,id=ocipass \
 # Point the default setup at this layer's mucoll-stack root. Only the analysis
 # root is installed in this image, so the spack find query is unambiguous.
 RUN . ${HOME}/setup_env.sh && \
-    MUCOLL_STACK_PATH=$(spack find --format "{prefix}" mucoll-stack~devtools+pytools+analysis~reco~sim~ml) && \
+    MUCOLL_STACK_PATH=$(spack find --format "{prefix}" mucoll-stack~devtools+pytools+analysis~sim~ml) && \
     MUCOLL_STACK_PATH_CLEANED=$(echo ${MUCOLL_STACK_PATH} | sed -E 's/\x1b\[[0-9;]*m//g') && \
     echo "source ${MUCOLL_STACK_PATH_CLEANED}/setup.sh" > /opt/setup_mucoll.sh && \
     echo "alias setup_mucoll=\". ${MUCOLL_STACK_PATH_CLEANED}/setup.sh\"" >> /etc/profile.d/aliases.sh

--- a/Docker/Dockerfile.layer
+++ b/Docker/Dockerfile.layer
@@ -31,6 +31,7 @@ RUN --mount=type=secret,id=ocipass \
     OCI_PASSWORD=$(cat /run/secrets/ocipass) spack install --only-concrete --no-add --fail-fast "${SPEC}" && \
     { spack mirror remove local-buildcache || true; } && \
     spack env deactivate && \
+    spack gc -y && \
     spack clean -a
 
 # Point the default setup at this layer's mucoll-stack root. The query selects

--- a/Docker/Dockerfile.layer
+++ b/Docker/Dockerfile.layer
@@ -9,7 +9,7 @@
 #  (pulled from / pushed back to the buildcache when available).
 ###############################################################################
 
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ghcr.io/muoncollidersoft/mucoll-analysis-ubuntu24:latest
 FROM ${BASE_IMAGE}
 
 # e.g. mucoll-stack+devtools+pytools+analysis+sim  or  ...+analysis+sim+ml

--- a/environments/mucoll-common/packages.yaml
+++ b/environments/mucoll-common/packages.yaml
@@ -121,14 +121,16 @@ packages:
   # py-torch / onnxruntime deps). The sim layer concretizes acts~gnn.
   acts:
     require: '@main+dd4hep+json cxxstd=20'
+  # Testing the madbaron fork branch that adds the K4GEO_USE_GEANT4 option
+  # (overlay recipe packages/k4geo). Revert to '@main' once it is upstreamed.
   k4geo:
-    require: '@main'
+    require: '@optional-geant4-plugin'
   k4gen:
     require: '@main'
   k4gaudipandora:
     require: '@main'
   k4reco:
-    require: '@0.2'
+    require: '@main'
   k4marlinwrapper:
     require: '@main'
   # NOTE: k4actstracking version is intentionally NOT pinned globally here.

--- a/environments/mucoll-common/packages.yaml
+++ b/environments/mucoll-common/packages.yaml
@@ -121,12 +121,12 @@ packages:
   # py-torch / onnxruntime deps). The sim layer concretizes acts~gnn.
   acts:
     require: '@main+dd4hep+json cxxstd=20'
-  # Testing the madbaron fork branch that adds the K4GEO_USE_GEANT4 option
-  # (overlay recipe packages/k4geo). Revert to '@main' once it is upstreamed.
   # ~beampipe_stl: skip the network download of the FCC-ee MDI beampipe CAD,
-  # which MuColl does not use (and which intermittently breaks the build).
+  # which MuColl does not use (and which intermittently breaks the build). The
+  # beampipe_stl variant is added by the packages/k4geo overlay; the rest mirrors
+  # upstream key4hep/k4geo@main.
   k4geo:
-    require: '@optional-geant4-plugin ~beampipe_stl'
+    require: '@main ~beampipe_stl'
   k4gen:
     require: '@main'
   k4gaudipandora:

--- a/environments/mucoll-common/packages.yaml
+++ b/environments/mucoll-common/packages.yaml
@@ -123,8 +123,10 @@ packages:
     require: '@main+dd4hep+json cxxstd=20'
   # Testing the madbaron fork branch that adds the K4GEO_USE_GEANT4 option
   # (overlay recipe packages/k4geo). Revert to '@main' once it is upstreamed.
+  # ~beampipe_stl: skip the network download of the FCC-ee MDI beampipe CAD,
+  # which MuColl does not use (and which intermittently breaks the build).
   k4geo:
-    require: '@optional-geant4-plugin'
+    require: '@optional-geant4-plugin ~beampipe_stl'
   k4gen:
     require: '@main'
   k4gaudipandora:

--- a/environments/mucoll-common/packages.yaml
+++ b/environments/mucoll-common/packages.yaml
@@ -55,14 +55,38 @@ packages:
     - spec: llvm@20.1.8 +clang +lld
       prefix: /usr/lib/llvm-20
 
+  boost:
+    require: +python
+    buildable: true
+
+  # Ask for Python > 3.11
+  # Since many packages depend on setuptools that was dropped in 3.12,
+  # without asking explicitly the version used will be 3.11
+  python:
+    require: "@3.12: +optimizations"
+
+
   # needed by Alma9 to support AVX2 instructions
   binutils:
     require: +gas
   gdb:
     require: +python+tui+source-highlight~debuginfod
 
+  xrootd:
+    require: +krb5 cxxstd=20
+
+  root:
+    require: '@6.36: +davix+fftw+gsl+math+minuit+mlp+opengl~pythia8+python+r+roofit+root7+rpath~shadow+spectrum+sqlite+ssl+tbb+tmva+tmva-cpu+unuran+vc+vdt+webgui+x+xml+xrootd +ipo cxxstd=20'
+
+  hdf5:
+    require: +cxx+hl
+  hepmc3:
+    require: +python+rootio
+  
   py-pandas:
     require: ~excel~parquet
+  py-numpy:
+    require: ^openblas
 
   # Pin py-torch to the latest series. py-torch@2.9.1 is available and every
   # root concretizes to it individually, but under `unify: when_possible` the
@@ -74,7 +98,18 @@ packages:
   # excludes 2.7.1 is enough to let the newest release win. Use a floor (not an
   # exact pin) so future releases are picked up automatically.
   py-torch:
-    require: '@2.8:'
+    require: '@2.8:~cuda+custom-protobuf'
+
+  # The versions of py-onnx and py-onnxruntime should be consistent based on this table
+  # https://onnxruntime.ai/docs/reference/compatibility.html#onnx-opset-support
+  py-onnx:
+    require: '@1.16:'
+  py-onnxruntime:
+    require: '@1.18:'
+    
+  geant4:
+    require: ~opengl~qt~vecgeom +ipo cxxstd=20
+
 
   k4fwcore:
     require: '@main'

--- a/environments/mucoll-layered/spack.yaml
+++ b/environments/mucoll-layered/spack.yaml
@@ -38,6 +38,6 @@ spack:
   # the ml root uses @gnn (which is why unify is when_possible, not true).
   specs:
   - mucoll-stack+devtools+pytools+analysis~reco~sim~ml
-  - mucoll-stack+devtools+pytools+analysis+reco~sim~ml ^k4actstracking@calosurface-extrapolation
+  - mucoll-stack+devtools+pytools+analysis+reco~sim~ml ^k4actstracking@calosurface-extrapolation^geant4~data
   - mucoll-stack+devtools+pytools+analysis+reco+sim~ml ^k4actstracking@calosurface-extrapolation
   - mucoll-stack+devtools+pytools+analysis+reco+sim+ml ^k4actstracking@gnn

--- a/environments/mucoll-layered/spack.yaml
+++ b/environments/mucoll-layered/spack.yaml
@@ -35,14 +35,16 @@ spack:
   # overlap: `+analysis` is satisfied by all four (installs everything), while
   # `+analysis~reco~sim~ml` is satisfied by none of the un-negated roots.
 
-  # Per-root Geant4 split: the reco root forces dd4hep~ddg4 AND k4geo~geant4 (so
-  # neither dd4hep nor k4geo's G4 plugin pulls Geant4 -> no Geant4 in the reco
-  # image), while sim/ml force dd4hep+ddg4 / k4geo+geant4 (Geant4 + its data,
-  # needed for ddsim). Pinning per-root makes the solver keep two dd4hep / two
-  # k4geo nodes instead of unifying them under when_possible (same pattern as
-  # k4actstracking).
+  # Per-root Geant4 split. The reco root needs k4SimGeant4 (for GeoSvc) so it
+  # carries Geant4, but only the libraries -- geant4~data keeps the multi-GB
+  # physics datasets out, since reco never runs Geant4 (EnableGeant4Geo=False).
+  # k4geo~geant4 still skips k4geo's own (unused) G4 plugin. The sim/ml roots use
+  # geant4+data and k4geo+geant4 for actual ddsim. Pinning per-root makes the
+  # solver keep separate geant4/dd4hep/k4simgeant4/k4geo nodes for reco vs sim/ml
+  # under when_possible (same pattern as k4actstracking); the Geant4-linked
+  # subtree is therefore built once per data variant.
   specs:
   - mucoll-stack~devtools+pytools+analysis~reco~sim~ml
-  - mucoll-stack~devtools+pytools+analysis+reco~sim~ml ^dd4hep~ddg4 ^k4geo~geant4 ^k4actstracking@calosurface-extrapolation
-  - mucoll-stack~devtools+pytools+analysis+reco+sim~ml ^dd4hep+ddg4 ^k4geo+geant4 ^k4actstracking@calosurface-extrapolation
-  - mucoll-stack~devtools+pytools+analysis+reco+sim+ml ^dd4hep+ddg4 ^k4geo+geant4 ^k4actstracking@gnn
+  - mucoll-stack~devtools+pytools+analysis+reco~sim~ml ^dd4hep+ddg4 ^geant4~data ^k4geo~geant4 ^k4actstracking@calosurface-extrapolation
+  - mucoll-stack~devtools+pytools+analysis+reco+sim~ml ^dd4hep+ddg4 ^geant4+data ^k4geo+geant4 ^k4actstracking@calosurface-extrapolation
+  - mucoll-stack~devtools+pytools+analysis+reco+sim+ml ^dd4hep+ddg4 ^geant4+data ^k4geo+geant4 ^k4actstracking@gnn

--- a/environments/mucoll-layered/spack.yaml
+++ b/environments/mucoll-layered/spack.yaml
@@ -35,8 +35,14 @@ spack:
   # overlap: `+analysis` is satisfied by all four (installs everything), while
   # `+analysis~reco~sim~ml` is satisfied by none of the un-negated roots.
 
+  # Per-root Geant4 split: the reco root forces dd4hep~ddg4 AND k4geo~geant4 (so
+  # neither dd4hep nor k4geo's G4 plugin pulls Geant4 -> no Geant4 in the reco
+  # image), while sim/ml force dd4hep+ddg4 / k4geo+geant4 (Geant4 + its data,
+  # needed for ddsim). Pinning per-root makes the solver keep two dd4hep / two
+  # k4geo nodes instead of unifying them under when_possible (same pattern as
+  # k4actstracking).
   specs:
   - mucoll-stack~devtools+pytools+analysis~reco~sim~ml
-  - mucoll-stack~devtools+pytools+analysis+reco~sim~ml ^k4actstracking@calosurface-extrapolation^geant4~data
-  - mucoll-stack~devtools+pytools+analysis+reco+sim~ml ^k4actstracking@calosurface-extrapolation^geant4+data
-  - mucoll-stack~devtools+pytools+analysis+reco+sim+ml ^k4actstracking@gnn^geant4+data
+  - mucoll-stack~devtools+pytools+analysis+reco~sim~ml ^dd4hep~ddg4 ^k4geo~geant4 ^k4actstracking@calosurface-extrapolation
+  - mucoll-stack~devtools+pytools+analysis+reco+sim~ml ^dd4hep+ddg4 ^k4geo+geant4 ^k4actstracking@calosurface-extrapolation
+  - mucoll-stack~devtools+pytools+analysis+reco+sim+ml ^dd4hep+ddg4 ^k4geo+geant4 ^k4actstracking@gnn

--- a/environments/mucoll-layered/spack.yaml
+++ b/environments/mucoll-layered/spack.yaml
@@ -12,7 +12,7 @@ spack:
 
   concretizer:
     # when_possible (not true) because the ml root requires a different
-    # k4actstracking branch (@gnn) than the reco/sim roots
+    # k4actstracking branch (@gnn) than the sim root
     # (@calosurface-extrapolation) and therefore cannot share a single DAG. Spack
     # still concretizes the whole environment together and shares every package
     # it can; only the conflicting k4actstracking subtree is duplicated.
@@ -25,26 +25,22 @@ spack:
   include:
   - ../mucoll-common/packages.yaml
 
-  # Four nested root specs (analysis ⊂ reco ⊂ sim ⊂ ml) concretized together
-  # under unify:when_possible so every shared dependency resolves to a single
-  # hash. Each layered image installs only its own root spec, reusing the parent
+  # Three nested root specs (analysis ⊂ sim ⊂ ml) concretized together under
+  # unify:when_possible so every shared dependency resolves to a single hash.
+  # Each layered image installs only its own root spec, reusing the parent
   # layer's already-installed store.
-  # The variants are written out explicitly (incl. the negations) so that each
+  #
+  # There is no separate reco image: the +sim variant covers both reconstruction
+  # and simulation, so the sim/ml roots carry +sim. sim/ml need Geant4 for ddsim
+  # (dd4hep+ddg4, geant4+data) -- a single shared geant4 across both, no
+  # data-variant split. The analysis root stays Geant4-free. Only the
+  # k4actstracking branch differs (sim @calosurface-extrapolation vs ml @gnn),
+  # hence unify:when_possible.
+  #
+  # The variants are written out explicitly (incl. the negations) so each
   # abstract root is matched by exactly one `spack install <spec>` query in the
-  # layered Dockerfiles. Without the ~reco/~sim/~ml negations the abstract roots
-  # overlap: `+analysis` is satisfied by all four (installs everything), while
-  # `+analysis~reco~sim~ml` is satisfied by none of the un-negated roots.
-
-  # Per-root Geant4 split. The reco root needs k4SimGeant4 (for GeoSvc) so it
-  # carries Geant4, but only the libraries -- geant4~data keeps the multi-GB
-  # physics datasets out, since reco never runs Geant4 (EnableGeant4Geo=False).
-  # k4geo~geant4 still skips k4geo's own (unused) G4 plugin. The sim/ml roots use
-  # geant4+data and k4geo+geant4 for actual ddsim. Pinning per-root makes the
-  # solver keep separate geant4/dd4hep/k4simgeant4/k4geo nodes for reco vs sim/ml
-  # under when_possible (same pattern as k4actstracking); the Geant4-linked
-  # subtree is therefore built once per data variant.
+  # layered Dockerfiles (e.g. ~sim~ml selects only analysis; +sim~ml only sim).
   specs:
-  - mucoll-stack~devtools+pytools+analysis~reco~sim~ml
-  - mucoll-stack~devtools+pytools+analysis+reco~sim~ml ^dd4hep+ddg4 ^geant4~data ^k4geo~geant4 ^k4actstracking@calosurface-extrapolation
-  - mucoll-stack~devtools+pytools+analysis+reco+sim~ml ^dd4hep+ddg4 ^geant4+data ^k4geo+geant4 ^k4actstracking@calosurface-extrapolation
-  - mucoll-stack~devtools+pytools+analysis+reco+sim+ml ^dd4hep+ddg4 ^geant4+data ^k4geo+geant4 ^k4actstracking@gnn
+  - mucoll-stack~devtools+pytools+analysis~sim~ml
+  - mucoll-stack~devtools+pytools+analysis+sim~ml ^dd4hep+ddg4 ^geant4+data ^k4actstracking@calosurface-extrapolation
+  - mucoll-stack~devtools+pytools+analysis+sim+ml ^dd4hep+ddg4 ^geant4+data ^k4actstracking@gnn

--- a/environments/mucoll-layered/spack.yaml
+++ b/environments/mucoll-layered/spack.yaml
@@ -34,10 +34,9 @@ spack:
   # layered Dockerfiles. Without the ~reco/~sim/~ml negations the abstract roots
   # overlap: `+analysis` is satisfied by all four (installs everything), while
   # `+analysis~reco~sim~ml` is satisfied by none of the un-negated roots.
-  # The reco and sim roots share k4actstracking@calosurface-extrapolation; only
-  # the ml root uses @gnn (which is why unify is when_possible, not true).
+
   specs:
-  - mucoll-stack+devtools+pytools+analysis~reco~sim~ml
-  - mucoll-stack+devtools+pytools+analysis+reco~sim~ml ^k4actstracking@calosurface-extrapolation^geant4~data
-  - mucoll-stack+devtools+pytools+analysis+reco+sim~ml ^k4actstracking@calosurface-extrapolation^geant4+data
-  - mucoll-stack+devtools+pytools+analysis+reco+sim+ml ^k4actstracking@gnn^geant4+data
+  - mucoll-stack~devtools+pytools+analysis~reco~sim~ml
+  - mucoll-stack~devtools+pytools+analysis+reco~sim~ml ^k4actstracking@calosurface-extrapolation^geant4~data
+  - mucoll-stack~devtools+pytools+analysis+reco+sim~ml ^k4actstracking@calosurface-extrapolation^geant4+data
+  - mucoll-stack~devtools+pytools+analysis+reco+sim+ml ^k4actstracking@gnn^geant4+data

--- a/environments/mucoll-layered/spack.yaml
+++ b/environments/mucoll-layered/spack.yaml
@@ -39,5 +39,5 @@ spack:
   specs:
   - mucoll-stack+devtools+pytools+analysis~reco~sim~ml
   - mucoll-stack+devtools+pytools+analysis+reco~sim~ml ^k4actstracking@calosurface-extrapolation^geant4~data
-  - mucoll-stack+devtools+pytools+analysis+reco+sim~ml ^k4actstracking@calosurface-extrapolation
-  - mucoll-stack+devtools+pytools+analysis+reco+sim+ml ^k4actstracking@gnn
+  - mucoll-stack+devtools+pytools+analysis+reco+sim~ml ^k4actstracking@calosurface-extrapolation^geant4+data
+  - mucoll-stack+devtools+pytools+analysis+reco+sim+ml ^k4actstracking@gnn^geant4+data

--- a/environments/mucoll-layered/spack.yaml
+++ b/environments/mucoll-layered/spack.yaml
@@ -11,8 +11,9 @@ spack:
         glu: [mesa]
 
   concretizer:
-    # when_possible (not true) because the sim and ml roots require different
-    # k4actstracking branches and therefore cannot share a single DAG. Spack
+    # when_possible (not true) because the ml root requires a different
+    # k4actstracking branch (@gnn) than the reco/sim roots
+    # (@calosurface-extrapolation) and therefore cannot share a single DAG. Spack
     # still concretizes the whole environment together and shares every package
     # it can; only the conflicting k4actstracking subtree is duplicated.
     unify: when_possible
@@ -24,16 +25,19 @@ spack:
   include:
   - ../mucoll-common/packages.yaml
 
-  # Three nested root specs (analysis ⊂ sim ⊂ ml) concretized together under
-  # unify:true so every shared dependency resolves to a single hash. Each
-  # layered image installs only its own root spec, reusing the parent layer's
-  # already-installed store.
-  # The sim/ml variants are written out explicitly (incl. the negations) so that
-  # each abstract root is matched by exactly one `spack install <spec>` query in
-  # the layered Dockerfiles. Without the ~sim~ml / ~ml negations the abstract
-  # roots overlap: `+analysis` is satisfied by all three (installs everything),
-  # while `+analysis~sim~ml` is satisfied by none of the un-negated roots.
+  # Four nested root specs (analysis ⊂ reco ⊂ sim ⊂ ml) concretized together
+  # under unify:when_possible so every shared dependency resolves to a single
+  # hash. Each layered image installs only its own root spec, reusing the parent
+  # layer's already-installed store.
+  # The variants are written out explicitly (incl. the negations) so that each
+  # abstract root is matched by exactly one `spack install <spec>` query in the
+  # layered Dockerfiles. Without the ~reco/~sim/~ml negations the abstract roots
+  # overlap: `+analysis` is satisfied by all four (installs everything), while
+  # `+analysis~reco~sim~ml` is satisfied by none of the un-negated roots.
+  # The reco and sim roots share k4actstracking@calosurface-extrapolation; only
+  # the ml root uses @gnn (which is why unify is when_possible, not true).
   specs:
-  - mucoll-stack+devtools+pytools+analysis~sim~ml
-  - mucoll-stack+devtools+pytools+analysis+sim~ml ^k4actstracking@calosurface-extrapolation
-  - mucoll-stack+devtools+pytools+analysis+sim+ml ^k4actstracking@gnn
+  - mucoll-stack+devtools+pytools+analysis~reco~sim~ml
+  - mucoll-stack+devtools+pytools+analysis+reco~sim~ml ^k4actstracking@calosurface-extrapolation
+  - mucoll-stack+devtools+pytools+analysis+reco+sim~ml ^k4actstracking@calosurface-extrapolation
+  - mucoll-stack+devtools+pytools+analysis+reco+sim+ml ^k4actstracking@gnn

--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -9,31 +9,36 @@ from spack.package import *
 class K4geo(CMakePackage):
     """DD4hep geometry models for future colliders.
 
-    MuColl overlay of the upstream key4hep/k4geo recipe. It points at the
-    madbaron fork and adds a ``geant4`` variant wired to the new
-    ``K4GEO_USE_GEANT4`` CMake option, so the Geant4-dependent k4geoG4 plugin
-    (the only part of k4geo that links DD4hep::DDG4 and Geant4) can be skipped.
-    Disabling it lets the reconstruction layer build k4geo with no Geant4 at all.
+    MuColl overlay of the upstream key4hep/k4geo recipe. The only addition is a
+    ``beampipe_stl`` variant: upstream ties INSTALL_BEAMPIPE_STL_FILES to the
+    ``compact`` variant, which downloads the FCC-ee MDI beampipe CAD over the
+    network at configure time (flaky, and unused by MuColl). This variant lets
+    the stack opt out (see packages.yaml: k4geo ... ~beampipe_stl).
     """
 
     homepage = "https://github.com/key4hep/k4geo"
-    git = "https://github.com/madbaron/k4geo.git"
+    git = "https://github.com/key4hep/k4geo.git"
     url = "https://github.com/key4hep/k4geo/archive/v00-16-07.tar.gz"
 
     generator = "Ninja"
 
     maintainers("jmcarcell", "madbaron")
 
-    # Test branch carrying the optional-Geant4-plugin change (madbaron fork).
-    version("optional-geant4-plugin", branch="optional-geant4-plugin")
     version("main", branch="main")
+    version(
+        "00-24",
+        sha256="3eefd973c0e534cc5cbb4d8fc079455508986bba49f859c30e0c23ac3e732f19",
+    )
+    version(
+        "00-23",
+        sha256="dd0c6300a6a2190a089012dfea271bd31050e8d4134ce09d896ebd81ef7391c5",
+    )
+    version(
+        "00-22",
+        sha256="95712eaf3452d29d35ac8156c37e5b4ea6449eb04073fb330bddc5df686f2cb3",
+    )
 
     variant("compact", default=True, description="Install compact files")
-    variant(
-        "geant4",
-        default=True,
-        description="Build the Geant4-dependent k4geoG4 plugin (requires DD4hep DDG4 and Geant4)",
-    )
     variant(
         "beampipe_stl",
         default=True,
@@ -43,10 +48,8 @@ class K4geo(CMakePackage):
     depends_on("cxx", type="build")
 
     depends_on("lcio")
-    depends_on("dd4hep@1.31:")
-    # The DDG4 component (and Geant4) are only needed for the k4geoG4 plugin.
-    depends_on("dd4hep+ddg4", when="+geant4")
-    depends_on("geant4", when="+geant4")
+    depends_on("dd4hep")
+    depends_on("dd4hep@1.31:", when="@0.22:")
     depends_on("root")
     depends_on("python", type="build")
     depends_on("ninja", type="build")
@@ -62,7 +65,6 @@ class K4geo(CMakePackage):
         # time, so this variant lets consumers opt out (the MuColl stack does,
         # via packages.yaml: it doesn't use the FCC-ee MDI beampipe CAD).
         args.append(self.define_from_variant("INSTALL_BEAMPIPE_STL_FILES", "beampipe_stl"))
-        args.append(self.define_from_variant("K4GEO_USE_GEANT4", "geant4"))
         args.append(self.define("BUILD_TESTING", self.run_tests))
         return args
 

--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -1,0 +1,102 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class K4geo(CMakePackage):
+    """DD4hep geometry models for future colliders.
+
+    MuColl overlay of the upstream key4hep/k4geo recipe. It points at the
+    madbaron fork and adds a ``geant4`` variant wired to the new
+    ``K4GEO_USE_GEANT4`` CMake option, so the Geant4-dependent k4geoG4 plugin
+    (the only part of k4geo that links DD4hep::DDG4 and Geant4) can be skipped.
+    Disabling it lets the reconstruction layer build k4geo with no Geant4 at all.
+    """
+
+    homepage = "https://github.com/key4hep/k4geo"
+    git = "https://github.com/madbaron/k4geo.git"
+    url = "https://github.com/key4hep/k4geo/archive/v00-16-07.tar.gz"
+
+    generator = "Ninja"
+
+    maintainers("jmcarcell", "madbaron")
+
+    # Test branch carrying the optional-Geant4-plugin change (madbaron fork).
+    version("optional-geant4-plugin", branch="optional-geant4-plugin")
+    version("main", branch="main")
+
+    variant("compact", default=True, description="Install compact files")
+    variant(
+        "geant4",
+        default=True,
+        description="Build the Geant4-dependent k4geoG4 plugin (requires DD4hep DDG4 and Geant4)",
+    )
+
+    depends_on("cxx", type="build")
+
+    depends_on("lcio")
+    depends_on("dd4hep@1.31:")
+    # The DDG4 component (and Geant4) are only needed for the k4geoG4 plugin.
+    depends_on("dd4hep+ddg4", when="+geant4")
+    depends_on("geant4", when="+geant4")
+    depends_on("root")
+    depends_on("python", type="build")
+    depends_on("ninja", type="build")
+    depends_on("podio")
+
+    def cmake_args(self):
+        args = []
+        args.append(
+            f"-DCMAKE_CXX_STANDARD={self.spec['root'].variants['cxxstd'].value}"
+        )
+        args.append(self.define_from_variant("INSTALL_COMPACT_FILES", "compact"))
+        # Automatically install the CAD beampipe files if we install the compact files
+        args.append(
+            self.define(
+                "INSTALL_BEAMPIPE_STL_FILES", self.spec.variants["compact"].value
+            )
+        )
+        args.append(self.define_from_variant("K4GEO_USE_GEANT4", "geant4"))
+        args.append(self.define("BUILD_TESTING", self.run_tests))
+        return args
+
+    def setup_run_environment(self, env):
+        env.set("LCGEO", self.prefix.share.k4geo)
+        env.set("K4GEO", self.prefix.share.k4geo)
+        env.set("lcgeo_DIR", self.prefix.share.k4geo)
+        env.set("k4geo_DIR", self.prefix.share.k4geo)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["k4geo"].libs.directories[0])
+
+    def setup_build_environment(self, env):
+        env.set("LCGEO", self.prefix.share.k4geo)
+        env.set("lcgeo_DIR", self.prefix.share.k4geo)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["lcio"].libs.directories[0])
+        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.set("LCGEO", self.prefix.share.k4geo)
+        env.set("lcgeo_DIR", self.prefix.share.k4geo)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["k4geo"].libs.directories[0])
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["lcio"].libs.directories[0])
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set("LCGEO", self.prefix.share.k4geo)
+        env.set("lcgeo_DIR", self.prefix.share.k4geo)
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["k4geo"].libs.directories[0])
+        env.prepend_path("LD_LIBRARY_PATH", self.spec["lcio"].libs.directories[0])
+
+    # dd4hep tests need to run after install step:
+    # disable the usual check
+    def check(self):
+        pass
+
+    # instead add custom check step that runs after installation
+    @run_after("install")
+    def install_check(self):
+        print(self)
+        with working_dir(self.build_directory):
+            if self.run_tests:
+                ninja("test")

--- a/packages/k4geo/package.py
+++ b/packages/k4geo/package.py
@@ -34,6 +34,11 @@ class K4geo(CMakePackage):
         default=True,
         description="Build the Geant4-dependent k4geoG4 plugin (requires DD4hep DDG4 and Geant4)",
     )
+    variant(
+        "beampipe_stl",
+        default=True,
+        description="Download and install the FCC-ee MDI beampipe CAD (STL) files",
+    )
 
     depends_on("cxx", type="build")
 
@@ -53,12 +58,10 @@ class K4geo(CMakePackage):
             f"-DCMAKE_CXX_STANDARD={self.spec['root'].variants['cxxstd'].value}"
         )
         args.append(self.define_from_variant("INSTALL_COMPACT_FILES", "compact"))
-        # Automatically install the CAD beampipe files if we install the compact files
-        args.append(
-            self.define(
-                "INSTALL_BEAMPIPE_STL_FILES", self.spec.variants["compact"].value
-            )
-        )
+        # The beampipe STL files are downloaded from the network at configure
+        # time, so this variant lets consumers opt out (the MuColl stack does,
+        # via packages.yaml: it doesn't use the FCC-ee MDI beampipe CAD).
+        args.append(self.define_from_variant("INSTALL_BEAMPIPE_STL_FILES", "beampipe_stl"))
         args.append(self.define_from_variant("K4GEO_USE_GEANT4", "geant4"))
         args.append(self.define("BUILD_TESTING", self.run_tests))
         return args

--- a/packages/k4reco/package.py
+++ b/packages/k4reco/package.py
@@ -20,7 +20,6 @@ class K4reco(CMakePackage, Key4hepPackage):
     depends_on("edm4hep")
     depends_on("gaudi")
     depends_on("k4fwcore")
-    depends_on("k4simgeant4")
     depends_on("k4geo")
     depends_on("root")
     depends_on("fastjet") 

--- a/packages/mucoll-stack/package.py
+++ b/packages/mucoll-stack/package.py
@@ -47,12 +47,15 @@ class MucollStack(BundlePackage, Key4hepPackage):
     variant('analysis', default=False, description='Minimal build for analysis only')
     variant('reco', default=False, description='Build with reconstruction tools')
     variant('sim', default=False, description='Build with simulation tools')
+    variant('gen', default=False, description='Build with generators')
 
     # Add compilers to the build dependencies
     # so that we have them available to set them in the env script
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
+
+    depends_on('pelican')
 
     with when('+analysis'):
         depends_on('edm4hep')
@@ -61,13 +64,23 @@ class MucollStack(BundlePackage, Key4hepPackage):
     with when('+sim'):
         ############################### Key4hep ###############
         #######################################################
-        depends_on('whizard +lcio +openloops')
         #depends_on('k4marlinwrapper')
         #depends_on('k4simdelphes')
         #depends_on('k4simgeant4')
-        depends_on('k4geo')
+        depends_on('dd4hep')
+        depends_on('delphes')
 
-        #with when('+reco'):
+    with when('+gen'):
+        depends_on('whizard +lcio +openloops')
+        depends_on('hepmc3')
+
+    with when('+reco'):
+        # reco-only images stay Geant4-free (lighter). When +sim is also present
+        # the +sim block's full dd4hep wins, so this edge is gated off to avoid a
+        # ~ddg4/+ddg4 clash on the shared dd4hep node.
+        depends_on('dd4hep~ddg4', when='~sim')
+
+        depends_on('k4geo')
         depends_on('k4reco')
         depends_on('k4gaudipandora')
         depends_on('k4actstracking')
@@ -107,11 +120,6 @@ class MucollStack(BundlePackage, Key4hepPackage):
         #######################################################
         depends_on('muoncvxddigitiser')
         depends_on('mybibutils')
-        depends_on('pelican')
-    
-        ############ generic packages ############
-        #######################################################
-        depends_on('delphes')
 
     ##################### developer tools #################
     #######################################################

--- a/packages/mucoll-stack/package.py
+++ b/packages/mucoll-stack/package.py
@@ -45,8 +45,7 @@ class MucollStack(BundlePackage, Key4hepPackage):
     variant('ml', default=False, description='Build with machine learning tools')
     variant('pytools', default=False, description='Build with python tools')
     variant('analysis', default=False, description='Minimal build for analysis only')
-    variant('reco', default=False, description='Build with reconstruction tools')
-    variant('sim', default=False, description='Build with simulation tools')
+    variant('sim', default=False, description='Build with reconstruction and simulation tools')
     variant('gen', default=False, description='Build with generators')
 
     # Add compilers to the build dependencies
@@ -65,27 +64,15 @@ class MucollStack(BundlePackage, Key4hepPackage):
     with when('+sim'):
         ############################### Key4hep ###############
         #######################################################
-        #depends_on('k4marlinwrapper')
-        #depends_on('k4simdelphes')
-        #depends_on('k4simgeant4')
         depends_on('dd4hep')
         depends_on('delphes')
-
-    with when('+gen'):
-        depends_on('whizard +lcio +openloops')
-        depends_on('hepmc3')
-
-    with when('+reco'):
-        depends_on('dd4hep')
 
         depends_on('k4geo')
         depends_on('k4reco')
         depends_on('k4gaudipandora')
         depends_on('k4actstracking')
-        # k4SimGeant4 provides the GeoSvc that the MAIA/MuColl reco workflow
-        # loads at runtime (with EnableGeant4Geo=False). It links Geant4, so the
-        # reco image carries the Geant4 libraries (but not the physics data --
-        # see geant4~data on the reco root in environments/mucoll-layered).
+        # k4SimGeant4 provides the GeoSvc that the MAIA/MuColl reconstruction
+        # workflow loads at runtime (with EnableGeant4Geo=False).
         depends_on('k4simgeant4')
 
         ############################### ILCSoft ###############
@@ -123,6 +110,10 @@ class MucollStack(BundlePackage, Key4hepPackage):
         #######################################################
         depends_on('muoncvxddigitiser')
         depends_on('mybibutils')
+
+    with when('+gen'):
+        depends_on('whizard +lcio +openloops')
+        depends_on('hepmc3')
 
     ##################### developer tools #################
     #######################################################

--- a/packages/mucoll-stack/package.py
+++ b/packages/mucoll-stack/package.py
@@ -78,7 +78,8 @@ class MucollStack(BundlePackage, Key4hepPackage):
         # reco-only images stay Geant4-free (lighter). When +sim is also present
         # the +sim block's full dd4hep wins, so this edge is gated off to avoid a
         # ~ddg4/+ddg4 clash on the shared dd4hep node.
-        depends_on('dd4hep~ddg4', when='~sim')
+        #depends_on('dd4hep~ddg4', when='~sim')
+        depends_on('dd4hep')
 
         depends_on('k4geo')
         depends_on('k4reco')

--- a/packages/mucoll-stack/package.py
+++ b/packages/mucoll-stack/package.py
@@ -55,6 +55,7 @@ class MucollStack(BundlePackage, Key4hepPackage):
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
 
+    depends_on('cmake')
     depends_on('pelican')
 
     with when('+analysis'):
@@ -125,7 +126,6 @@ class MucollStack(BundlePackage, Key4hepPackage):
     ##################### developer tools #################
     #######################################################
     with when('+devtools'):
-        depends_on('cmake')
         depends_on('ninja')
         depends_on('doxygen')
         depends_on('gdb')

--- a/packages/mucoll-stack/package.py
+++ b/packages/mucoll-stack/package.py
@@ -76,16 +76,17 @@ class MucollStack(BundlePackage, Key4hepPackage):
         depends_on('hepmc3')
 
     with when('+reco'):
-        # reco-only images stay Geant4-free (lighter). When +sim is also present
-        # the +sim block's full dd4hep wins, so this edge is gated off to avoid a
-        # ~ddg4/+ddg4 clash on the shared dd4hep node.
-        #depends_on('dd4hep~ddg4', when='~sim')
         depends_on('dd4hep')
 
         depends_on('k4geo')
         depends_on('k4reco')
         depends_on('k4gaudipandora')
         depends_on('k4actstracking')
+        # k4SimGeant4 provides the GeoSvc that the MAIA/MuColl reco workflow
+        # loads at runtime (with EnableGeant4Geo=False). It links Geant4, so the
+        # reco image carries the Geant4 libraries (but not the physics data --
+        # see geant4~data on the reco root in environments/mucoll-layered).
+        depends_on('k4simgeant4')
 
         ############################### ILCSoft ###############
         #######################################################

--- a/validation/run_chain.sh
+++ b/validation/run_chain.sh
@@ -87,7 +87,7 @@ case "${STAGE}" in
       --inputFiles gen.edm4hep.root \
       --outputFile sim.edm4hep.root \
       # We cannot afford to run with HP in the CI validation
-      --physicsList FTFP_BERT \
+      --physics.list FTFP_BERT \
       --numberOfEvents "${NEV}"
     ;;
 

--- a/validation/run_chain.sh
+++ b/validation/run_chain.sh
@@ -86,6 +86,8 @@ case "${STAGE}" in
     ddsim --steeringFile "${BM}/simulation/steer_baseline.py" \
       --inputFiles gen.edm4hep.root \
       --outputFile sim.edm4hep.root \
+      # We cannot afford to run with HP in the CI validation
+      --physicsList FTFP_BERT \
       --numberOfEvents "${NEV}"
     ;;
 

--- a/validation/run_chain.sh
+++ b/validation/run_chain.sh
@@ -83,10 +83,10 @@ case "${STAGE}" in
     ;;
 
   sim)
+    # We cannot afford to run with HP in the CI validation
     ddsim --steeringFile "${BM}/simulation/steer_baseline.py" \
       --inputFiles gen.edm4hep.root \
       --outputFile sim.edm4hep.root \
-      # We cannot afford to run with HP in the CI validation
       --physics.list FTFP_BERT \
       --numberOfEvents "${NEV}"
     ;;


### PR DESCRIPTION
I initially wanted to introduce also a middle "reco" layer, but it's essentially impossible to build that without having to duplicate the geant installation downstream making the sim and ml 1GB larger for no good reason.

