### PR TITLE
Move ml to analysis

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: Build MuColl Stack and Publish Image
 description: |
   Publish the layered mucoll software stack docker images:
-  mucoll-analysis -> mucoll-sim -> mucoll-ml.
+  mucoll-analysis -> mucoll-sim.
   The +sim variant covers both reconstruction and simulation; there is no
   separate reco image.
   Each layer is built FROM the previous one (per architecture) so packages are
@@ -34,7 +34,7 @@ jobs:
       registry: ghcr.io
       image-type: analysis
       dockerfile: Dockerfile.base
-      spec: mucoll-stack~devtools+pytools+analysis~sim~ml
+      spec: mucoll-stack~devtools+pytools+ml~sim
 
   analysis-arm64:
     uses: ./.github/workflows/docker-build-push-template.yaml
@@ -45,7 +45,7 @@ jobs:
       registry: ghcr.io
       image-type: analysis
       dockerfile: Dockerfile.base
-      spec: mucoll-stack~devtools+pytools+analysis~sim~ml
+      spec: mucoll-stack~devtools+pytools+ml~sim
 
   # --------------------------------------------------------------------- sim --
   # Built FROM analysis; the +sim variant installs the reconstruction +
@@ -61,7 +61,7 @@ jobs:
       image-type: sim
       dockerfile: Dockerfile.layer
       base-image: ${{ needs.analysis-amd64.outputs.image-uri }}
-      spec: mucoll-stack~devtools+pytools+analysis+sim~ml
+      spec: mucoll-stack~devtools+pytools+ml+sim
 
   sim-arm64:
     needs: analysis-arm64
@@ -74,34 +74,7 @@ jobs:
       image-type: sim
       dockerfile: Dockerfile.layer
       base-image: ${{ needs.analysis-arm64.outputs.image-uri }}
-      spec: mucoll-stack~devtools+pytools+analysis+sim~ml
-
-  # ---------------------------------------------------------------------- ml --
-  ml-amd64:
-    needs: sim-amd64
-    uses: ./.github/workflows/docker-build-push-template.yaml
-    with:
-      os: ubuntu24
-      runner: ubuntu-latest
-      platform: amd64
-      registry: ghcr.io
-      image-type: ml
-      dockerfile: Dockerfile.layer
-      base-image: ${{ needs.sim-amd64.outputs.image-uri }}
-      spec: mucoll-stack~devtools+pytools+analysis+sim+ml
-
-  ml-arm64:
-    needs: sim-arm64
-    uses: ./.github/workflows/docker-build-push-template.yaml
-    with:
-      os: ubuntu24
-      runner: ubuntu-24.04-arm
-      platform: arm64
-      registry: ghcr.io
-      image-type: ml
-      dockerfile: Dockerfile.layer
-      base-image: ${{ needs.sim-arm64.outputs.image-uri }}
-      spec: mucoll-stack~devtools+pytools+analysis+sim+ml
+      spec: mucoll-stack~devtools+pytools+ml+sim
 
   # --------------------------------------------------------------- manifests --
   manifest-analysis:
@@ -123,16 +96,6 @@ jobs:
       image-type: sim
       amd64-image: ${{ needs.sim-amd64.outputs.image-uri }}
       arm64-image: ${{ needs.sim-arm64.outputs.image-uri }}
-
-  manifest-ml:
-    needs: [ml-amd64, ml-arm64]
-    uses: ./.github/workflows/manifest-template.yaml
-    with:
-      os: ubuntu24
-      registry: ghcr.io
-      image-type: ml
-      amd64-image: ${{ needs.ml-amd64.outputs.image-uri }}
-      arm64-image: ${{ needs.ml-arm64.outputs.image-uri }}
 
   # ------------------------------------------------------ physics validation --
   physics-validation:

--- a/Docker/Dockerfile.base
+++ b/Docker/Dockerfile.base
@@ -165,7 +165,7 @@ RUN --mount=type=secret,id=ocipass \
 # Point the default setup at this layer's mucoll-stack root. Only the analysis
 # root is installed in this image, so the spack find query is unambiguous.
 RUN . ${HOME}/setup_env.sh && \
-    MUCOLL_STACK_PATH=$(spack find --format "{prefix}" mucoll-stack~devtools+pytools+analysis~sim~ml) && \
+    MUCOLL_STACK_PATH=$(spack find --format "{prefix}" mucoll-stack~devtools+pytools+ml~sim) && \
     MUCOLL_STACK_PATH_CLEANED=$(echo ${MUCOLL_STACK_PATH} | sed -E 's/\x1b\[[0-9;]*m//g') && \
     echo "source ${MUCOLL_STACK_PATH_CLEANED}/setup.sh" > /opt/setup_mucoll.sh && \
     echo "alias setup_mucoll=\". ${MUCOLL_STACK_PATH_CLEANED}/setup.sh\"" >> /etc/profile.d/aliases.sh

--- a/environments/mucoll-common/packages.yaml
+++ b/environments/mucoll-common/packages.yaml
@@ -96,6 +96,43 @@ packages:
   py-numpy:
     require: '@:2.2 ^openblas'
 
+  # The pins below (py-sympy, eigen, py-fsspec, valgrind) exist for the SAME
+  # reason as the numpy cap above: under unify:when_possible the lean analysis
+  # root takes the newest version/variant of a shared package while the richer
+  # +sim root is capped (by acts, acorn's ML deps, geant4, ...), so the two
+  # roots cannot share a hash and the package -- plus everything above it -- is
+  # duplicated. py-torch depends on ALL of py-sympy, eigen, py-fsspec and
+  # valgrind, so each split forks the (expensive) py-torch/onnxruntime subtree.
+  # Forcing one shared config collapses it to a single build per package.
+
+  # sim caps sympy at 1.13.3 (via acorn -> py-torch-geometric / py-lightning);
+  # analysis is free to take 1.14.0. py-torch (@2.7:) and py-onnxruntime both
+  # accept 1.13.3, so pinning it unifies py-onnxruntime AND one py-torch edge.
+  py-sympy:
+    require: '@1.13.3'
+
+  # sim caps eigen at the 3.4 series (acts does not support eigen@5); analysis
+  # would otherwise take eigen@5.0.1. py-torch works with 3.4 (the sim root
+  # proves it), so pin the 3.4 series everywhere.
+  eigen:
+    require: '@3.4'
+
+  # sim pulls py-fsspec+http (acorn -> py-lightning / py-torch-geometric need
+  # remote-dataset support); analysis takes ~http. Force +http so both agree;
+  # this unifies py-uproot / py-awkward and another py-torch edge. The extra
+  # py-aiohttp dependency is cheap.
+  py-fsspec:
+    require: '+http'
+
+  # py-torch is built +valgrind, and valgrind is built +boost by default. boost
+  # legitimately has two configs (a rich +filesystem/+program_options/... build
+  # for the sim stack vs a lean build for analysis), which would otherwise be
+  # dragged into py-torch through valgrind. Dropping valgrind's boost dependency
+  # severs that amplifier so py-torch stays a single build; boost itself may
+  # still have two (cheap) configs, but nothing expensive rides on the split.
+  valgrind:
+    require: '~boost'
+
   # Pin py-torch to the latest series. py-torch@2.9.1 is available and every
   # root concretizes to it individually, but under `unify: when_possible` the
   # solver's whole-DAG version optimization settles the *shared* py-torch on

--- a/environments/mucoll-common/packages.yaml
+++ b/environments/mucoll-common/packages.yaml
@@ -108,7 +108,7 @@ packages:
     require: '@1.18:'
     
   geant4:
-    require: ~opengl~qt~vecgeom +ipo cxxstd=20
+    require: ~opengl~qt~vecgeom~examples +ipo cxxstd=20
 
   edm4hep:
     require: '@main'

--- a/environments/mucoll-common/packages.yaml
+++ b/environments/mucoll-common/packages.yaml
@@ -118,9 +118,6 @@ packages:
 
   dd4hep:
     require: '+edm4hep+lcio+xercesc+hepmc3'
-  # +gnn is intentionally NOT required globally: only the @gnn branch of
-  # k4actstracking (used by the ml layer) needs the acts GNN plugin (and its
-  # py-torch / onnxruntime deps). The sim layer concretizes acts~gnn.
   acts:
     require: '@main+dd4hep+json cxxstd=20'
   # ~beampipe_stl: skip the network download of the FCC-ee MDI beampipe CAD,

--- a/environments/mucoll-common/packages.yaml
+++ b/environments/mucoll-common/packages.yaml
@@ -139,10 +139,8 @@ packages:
     require: '@main'
   k4edm4hep2lcioconv:
     require: '@main'
-  # NOTE: k4actstracking version is intentionally NOT pinned globally here.
-  # The sim and ml layers require different branches (@calosurface-extrapolation
-  # vs @gnn), so the version is constrained per-root in each environment's spec
-  # list instead (a global require would make those per-root specs unsatisfiable).
+  k4actstracking:
+    require: '@gnn+gnn'
   k4simgeant4:
     require: '@main'
   # The latest release (00-07-06) fails to build against k4fwcore@main: it still

--- a/environments/mucoll-common/packages.yaml
+++ b/environments/mucoll-common/packages.yaml
@@ -85,8 +85,16 @@ packages:
   
   py-pandas:
     require: ~excel~parquet
+  # Cap numpy at the numba-compatible ceiling (py-numba, pulled in via acorn in
+  # the +sim layer, does not yet support numpy@2.3). Without this cap the sim
+  # root concretizes numpy@2.2.6 (numba-limited) while the analysis root is free
+  # to take numpy@2.3.x; under unify:when_possible those cannot share a hash, so
+  # numpy AND everything depending on it (py-scipy, py-scikit-learn, py-xgboost)
+  # get duplicated across the two layered roots. Pinning both roots to <=2.2
+  # collapses that subtree to a single shared build. Use a ceiling (not an exact
+  # pin) so patch updates within 2.2.x are picked up automatically.
   py-numpy:
-    require: ^openblas
+    require: '@:2.2 ^openblas'
 
   # Pin py-torch to the latest series. py-torch@2.9.1 is available and every
   # root concretizes to it individually, but under `unify: when_possible` the

--- a/environments/mucoll-layered/spack.yaml
+++ b/environments/mucoll-layered/spack.yaml
@@ -11,7 +11,14 @@ spack:
         glu: [mesa]
 
   concretizer:
-    unify: true
+    # MUST be when_possible (not true). The two roots below are the *same*
+    # package (mucoll-stack) differing only in the `sim` variant (~sim vs +sim).
+    # unify:true permits exactly one configuration per package across the whole
+    # environment -- including the root -- so ~sim and +sim collide directly on
+    # the mucoll-stack node ("conflicting variant values '~sim' and '+sim'").
+    # when_possible lets the two root configurations coexist while still sharing
+    # every dependency the solver can prove identical.
+    unify: when_possible
     targets:
       host_compatible: true
 
@@ -21,9 +28,9 @@ spack:
   - ../mucoll-common/packages.yaml
 
   # Two nested root specs (analysis ⊂ sim) concretized together under
-  # unify:true so every shared dependency resolves to a single hash.
-  # Each layered image installs only its own root spec, reusing the parent
-  # layer's already-installed store.
+  # unify:when_possible so shared dependencies resolve to a single hash where
+  # the solver can prove them identical. Each layered image installs only its
+  # own root spec, reusing the parent layer's already-installed store.
   #
   # The variants are written out explicitly (incl. the negations) so each
   # abstract root is matched by exactly one `spack install <spec>` query in the

--- a/environments/mucoll-layered/spack.yaml
+++ b/environments/mucoll-layered/spack.yaml
@@ -11,12 +11,7 @@ spack:
         glu: [mesa]
 
   concretizer:
-    # when_possible (not true) because the ml root requires a different
-    # k4actstracking branch (@gnn) than the sim root
-    # (@calosurface-extrapolation) and therefore cannot share a single DAG. Spack
-    # still concretizes the whole environment together and shares every package
-    # it can; only the conflicting k4actstracking subtree is duplicated.
-    unify: when_possible
+    unify: true
     targets:
       host_compatible: true
 
@@ -25,21 +20,14 @@ spack:
   include:
   - ../mucoll-common/packages.yaml
 
-  # Three nested root specs (analysis ⊂ sim ⊂ ml) concretized together under
-  # unify:when_possible so every shared dependency resolves to a single hash.
+  # Two nested root specs (analysis ⊂ sim) concretized together under
+  # unify:true so every shared dependency resolves to a single hash.
   # Each layered image installs only its own root spec, reusing the parent
   # layer's already-installed store.
   #
-  # There is no separate reco image: the +sim variant covers both reconstruction
-  # and simulation, so the sim/ml roots carry +sim. sim/ml need Geant4 for ddsim
-  # (dd4hep+ddg4, geant4+data) -- a single shared geant4 across both, no
-  # data-variant split. The analysis root stays Geant4-free. Only the
-  # k4actstracking branch differs (sim @calosurface-extrapolation vs ml @gnn),
-  # hence unify:when_possible.
-  #
   # The variants are written out explicitly (incl. the negations) so each
   # abstract root is matched by exactly one `spack install <spec>` query in the
-  # layered Dockerfiles (e.g. ~sim~ml selects only analysis; +sim~ml only sim).
+  # layered Dockerfiles (e.g. ~sim selects only analysis).
   specs:
   - mucoll-stack~devtools+pytools+ml~sim
   - mucoll-stack~devtools+pytools+ml+sim

--- a/environments/mucoll-layered/spack.yaml
+++ b/environments/mucoll-layered/spack.yaml
@@ -41,6 +41,5 @@ spack:
   # abstract root is matched by exactly one `spack install <spec>` query in the
   # layered Dockerfiles (e.g. ~sim~ml selects only analysis; +sim~ml only sim).
   specs:
-  - mucoll-stack~devtools+pytools+analysis~sim~ml
-  - mucoll-stack~devtools+pytools+analysis+sim~ml ^dd4hep+ddg4 ^geant4+data ^k4actstracking@main
-  - mucoll-stack~devtools+pytools+analysis+sim+ml ^dd4hep+ddg4 ^geant4+data ^k4actstracking@gnn
+  - mucoll-stack~devtools+pytools+ml~sim
+  - mucoll-stack~devtools+pytools+ml+sim

--- a/environments/mucoll-release-debug/spack.yaml
+++ b/environments/mucoll-release-debug/spack.yaml
@@ -21,4 +21,4 @@ spack:
   - ../mucoll-common/packages.yaml
 
   specs:
-  - mucoll-stack+devtools+pytools+sim ^k4actstracking@calosurface-extrapolation
+  - mucoll-stack+devtools+pytools+sim+ml

--- a/packages/geant4/columns-10.patch
+++ b/packages/geant4/columns-10.patch
@@ -1,0 +1,13 @@
+diff --git a/source/externals/g4tools/include/tools/wroot/columns.icc b/source/externals/g4tools/include/tools/wroot/columns.icc
+index 0df2c16620..af9b15e0ab 100644
+--- a/source/analysis/g4tools/include/tools/wroot/columns.icc
++++ b/source/analysis/g4tools/include/tools/wroot/columns.icc
+@@ -399,7 +399,7 @@
+   protected:
+     std_vector_column_ref(const std_vector_column_ref& a_from)
+     :icol(a_from)
+-    ,m_branch(a_from.m_barnch)
++    ,m_branch(a_from.m_branch)
+     ,m_ref(a_from.m_ref)
+     ,m_leaf(0)
+     ,m_leaf_count(0)

--- a/packages/geant4/columns-11.patch
+++ b/packages/geant4/columns-11.patch
@@ -1,0 +1,13 @@
+diff --git a/source/externals/g4tools/include/tools/wroot/columns.icc b/source/externals/g4tools/include/tools/wroot/columns.icc
+index 0df2c16620..af9b15e0ab 100644
+--- a/source/externals/g4tools/include/tools/wroot/columns.icc
++++ b/source/externals/g4tools/include/tools/wroot/columns.icc
+@@ -399,7 +399,7 @@
+   protected:
+     std_vector_column_ref(const std_vector_column_ref& a_from)
+     :icol(a_from)
+-    ,m_branch(a_from.m_barnch)
++    ,m_branch(a_from.m_branch)
+     ,m_ref(a_from.m_ref)
+     ,m_leaf(0)
+     ,m_leaf_count(0)

--- a/packages/geant4/geant4-10.0.4.patch
+++ b/packages/geant4/geant4-10.0.4.patch
@@ -1,0 +1,31 @@
+diff -Naur a/cmake/Modules/Geant4MakeRules_cxx.cmake b/cmake/Modules/Geant4MakeRules_cxx.cmake
+--- a/cmake/Modules/Geant4MakeRules_cxx.cmake	2016-06-10 12:04:27
++++ b/cmake/Modules/Geant4MakeRules_cxx.cmake	2023-12-04 16:49:28
+@@ -51,7 +51,7 @@
+   elseif(_gnucxx_version VERSION_LESS 4.7)
+     set(_CXXSTDS "c++98" "c++0x")
+   else()
+-    set(_CXXSTDS "c++98" "c++0x" "c++11")
++    set(_CXXSTDS "c++98" "c++0x" "c++11" "c++14")
+   endif()
+
+   set(CXXSTD_IS_AVAILABLE ${_CXXSTDS} PARENT_SCOPE)
+diff -Naur a/source/visualization/HepRep/sources.cmake b/source/visualization/HepRep/sources.cmake
+--- a/source/visualization/HepRep/sources.cmake	2016-06-10 12:04:27
++++ b/source/visualization/HepRep/sources.cmake	2023-12-04 16:12:32
+@@ -71,13 +71,13 @@
+     G4HepRepMessenger.cc
+     G4HepRepSceneHandler.cc
+     G4HepRepViewer.cc
+-    GZIPOutputStream.cc
++    gzipoutputstream.cc
+     GZIPOutputStreamBuffer.cc
+     IndentPrintWriter.cc
+     XMLHepRepFactory.cc
+     XMLHepRepWriter.cc
+     XMLWriter.cc
+-    ZipOutputStream.cc
++    zipoutputstream.cc
+     ZipOutputStreamBuffer.cc
+   GRANULAR_DEPENDENCIES
+     G4csg

--- a/packages/geant4/geant4-10.3-cxx17-cmake.patch
+++ b/packages/geant4/geant4-10.3-cxx17-cmake.patch
@@ -1,0 +1,22 @@
+diff -Naur geant4.10.03.p03/cmake/Modules/Geant4LibraryBuildOptions.cmake geant4.10.03.p03/cmake/Modules/Geant4LibraryBuildOptions.cmake
+--- geant4.10.03.p03/cmake/Modules/Geant4LibraryBuildOptions.cmake	2017-10-20 06:30:46.000000000 -0500
++++ geant4.10.03.p03/cmake/Modules/Geant4LibraryBuildOptions.cmake	2018-04-16 16:48:02.194321171 -0500
+@@ -76,7 +76,7 @@
+ # Mark as advanced because most users will not need it
+ enum_option(GEANT4_BUILD_CXXSTD
+   DOC "C++ Standard to compile against"
+-  VALUES 11 14 c++11 c++14
++  VALUES 11 14 17 c++11 c++14 c++17
+   CASE_INSENSITIVE
+   )
+ 
+@@ -106,6 +106,9 @@
+ 
+ # Add Definition to flags for temporary back compatibility
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DG4USE_STD11")
++if(GEANT4_BUILD_CXXSTD GREATER 14)
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES=1")
++endif()
+ 
+ # Hold any appropriate compile flag(s) in variable for later export to
+ # config files. Needed to support late CMake 2.8 where compile features

--- a/packages/geant4/geant4-10.4-cxx17-cmake.patch
+++ b/packages/geant4/geant4-10.4-cxx17-cmake.patch
@@ -1,0 +1,22 @@
+diff -Naur geant4/cmake/Modules/G4BuildSettings.cmake geant4/cmake/Modules/G4BuildSettings.cmake
+--- geant4/cmake/Modules/G4BuildSettings.cmake	2017-10-20 06:30:46.000000000 -0500
++++ geant4/cmake/Modules/G4BuildSettings.cmake	2018-04-16 16:48:02.194321171 -0500
+@@ -76,7 +76,7 @@
+ # Mark as advanced because most users will not need it
+ enum_option(GEANT4_BUILD_CXXSTD
+   DOC "C++ Standard to compile against"
+-  VALUES 11 14 c++11 c++14
++  VALUES 11 14 17 c++11 c++14 c++17
+   CASE_INSENSITIVE
+   )
+ 
+@@ -106,6 +106,9 @@
+ 
+ # Add Definition to flags for temporary back compatibility
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DG4USE_STD11")
++if(GEANT4_BUILD_CXXSTD GREATER 14)
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES=1")
++endif()
+ 
+ # Hold any appropriate compile flag(s) in variable for later export to
+ # config files. Needed to support late CMake 2.8 where compile features

--- a/packages/geant4/geant4-10.4.3-cxx17-removed-features.patch
+++ b/packages/geant4/geant4-10.4.3-cxx17-removed-features.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/Modules/G4BuildSettings.cmake b/cmake/Modules/G4BuildSettings.cmake
+index f68cb0a44..6bf4b6948 100644
+--- a/cmake/Modules/G4BuildSettings.cmake
++++ b/cmake/Modules/G4BuildSettings.cmake
+@@ -205,6 +205,13 @@ endif()
+ # Add Definition to flags for temporary back compatibility
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DG4USE_STD11")
+ 
++# Spack patch to support use of C++ features deprecated/removed in C++17
++# Only checked on AppleClang for now
++if(GEANT4_BUILD_CXXSTD GREATER 14)
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES=1")
++endif()
++#----
++
+ # Hold any appropriate compile flag(s) in variable for later export to
+ # config files. Needed to support clients using late CMake 2.8 where compile features
+ # are not available.

--- a/packages/geant4/geant4-10.6.patch
+++ b/packages/geant4/geant4-10.6.patch
@@ -1,0 +1,98 @@
+From b19a720a77d6661662f5dd440d9bb7fb6dadd9fb Mon Sep 17 00:00:00 2001
+From: Seth R Johnson <johnsonsr@ornl.gov>
+Date: Wed, 13 Mar 2024 14:43:37 -0400
+Subject: [PATCH] Backport ascii-V10-07-03
+
+---
+ .../persistency/ascii/src/G4tgrEvaluator.cc   | 72 +++++++++----------
+ 1 file changed, 36 insertions(+), 36 deletions(-)
+
+diff --git a/source/persistency/ascii/src/G4tgrEvaluator.cc b/source/persistency/ascii/src/G4tgrEvaluator.cc
+index 9447ede9910..f20f3ca3404 100644
+--- a/source/persistency/ascii/src/G4tgrEvaluator.cc
++++ b/source/persistency/ascii/src/G4tgrEvaluator.cc
+@@ -63,45 +63,45 @@ void G4tgrEvaluator::print_error( G4int estatus ) const
+   }
+ } 
+  
+-G4double fsin( G4double arg ){  return std::sin(arg); }
+-G4double fcos( G4double arg ){  return std::cos(arg); }
+-G4double ftan( G4double arg ){  return std::tan(arg); }
+-G4double fasin( G4double arg ){  return std::asin(arg); }
+-G4double facos( G4double arg ){  return std::acos(arg); }
+-G4double fatan( G4double arg ){  return std::atan(arg); }
+-G4double fatan2( G4double arg1, G4double arg2 ){ return std::atan2(arg1,arg2); }
+-G4double fsinh( G4double arg ){  return std::sinh(arg); }
+-G4double fcosh( G4double arg ){  return std::cosh(arg); }
+-G4double ftanh( G4double arg ){  return std::tanh(arg); }
+-// G4double fasinh( G4double arg ){  return std::asinh(arg); }
+-// G4double facosh( G4double arg ){  return std::acosh(arg); }
+-// G4double fatanh( G4double arg ){  return std::atanh(arg); }
+-G4double fsqrt( G4double arg ){  return std::sqrt(arg); }
+-G4double fexp( G4double arg ){  return std::exp(arg); }
+-G4double flog( G4double arg ){  return std::log(arg); }
+-G4double flog10( G4double arg ){  return std::log10(arg); }
+-G4double fpow( G4double arg1, G4double arg2 ){  return std::pow(arg1,arg2); }
++G4double fltsin( G4double arg ){  return std::sin(arg); }
++G4double fltcos( G4double arg ){  return std::cos(arg); }
++G4double flttan( G4double arg ){  return std::tan(arg); }
++G4double fltasin( G4double arg ){  return std::asin(arg); }
++G4double fltacos( G4double arg ){  return std::acos(arg); }
++G4double fltatan( G4double arg ){  return std::atan(arg); }
++G4double fltatan2( G4double arg1, G4double arg2 ){ return std::atan2(arg1,arg2); }
++G4double fltsinh( G4double arg ){  return std::sinh(arg); }
++G4double fltcosh( G4double arg ){  return std::cosh(arg); }
++G4double flttanh( G4double arg ){  return std::tanh(arg); }
++// G4double fltasinh( G4double arg ){  return std::asinh(arg); }
++// G4double fltacosh( G4double arg ){  return std::acosh(arg); }
++// G4double fltatanh( G4double arg ){  return std::atanh(arg); }
++G4double fltsqrt( G4double arg ){  return std::sqrt(arg); }
++G4double fltexp( G4double arg ){  return std::exp(arg); }
++G4double fltlog( G4double arg ){  return std::log(arg); }
++G4double fltlog10( G4double arg ){  return std::log10(arg); }
++G4double fltpow( G4double arg1, G4double arg2 ){  return std::pow(arg1,arg2); }
+ 
+ 
+ //--------------------------------------------------------------------
+ void G4tgrEvaluator::AddCommonFunctions()
+ {
+-  setFunction("sin", (*fsin));
+-  setFunction("cos", (*fcos));
+-  setFunction("tan", (*ftan));
+-  setFunction("asin", (*fasin));
+-  setFunction("acos", (*facos));
+-  setFunction("atan", (*fatan));
+-  setFunction("atan2", (*fatan2));
+-  setFunction("sinh", (*fsinh));
+-  setFunction("cosh", (*fcosh));
+-  setFunction("tanh", (*ftanh));
+-//  setFunction("asinh", (*fasinh));
+-//  setFunction("acosh", (*facosh));
+-//  setFunction("atanh", (*fatanh));
+-  setFunction("sqrt", (*fsqrt));
+-  setFunction("exp", (*fexp));
+-  setFunction("log", (*flog));
+-  setFunction("log10", (*flog10));
+-  setFunction("pow", (*fpow));
++  setFunction("sin", (*fltsin));
++  setFunction("cos", (*fltcos));
++  setFunction("tan", (*flttan));
++  setFunction("asin", (*fltasin));
++  setFunction("acos", (*fltacos));
++  setFunction("atan", (*fltatan));
++  setFunction("atan2", (*fltatan2));
++  setFunction("sinh", (*fltsinh));
++  setFunction("cosh", (*fltcosh));
++  setFunction("tanh", (*flttanh));
++//  setFunction("asinh", (*fltasinh));
++//  setFunction("acosh", (*fltacosh));
++//  setFunction("atanh", (*fltatanh));
++  setFunction("sqrt", (*fltsqrt));
++  setFunction("exp", (*fltexp));
++  setFunction("log", (*fltlog));
++  setFunction("log10", (*fltlog10));
++  setFunction("pow", (*fltpow));
+ }
+-- 
+2.43.0
+

--- a/packages/geant4/geant4-10.7-cxx20-g3tog4.patch
+++ b/packages/geant4/geant4-10.7-cxx20-g3tog4.patch
@@ -1,0 +1,26 @@
+diff --git a/source/g3tog4/include/G3EleTable.hh b/source/g3tog4/include/G3EleTable.hh
+index 0ab9c4fd566..18c6f73fde6 100644
+--- a/source/g3tog4/include/G3EleTable.hh
++++ b/source/g3tog4/include/G3EleTable.hh
+@@ -56,7 +56,7 @@ public:  // with description
+ private:
+
+   void LoadUp();
+-  G4int parse(G4double& Z, char* name, char* sym, G4double& A); 
++  G4int parse(G4double& Z, char (&name)[20], char (&sym)[3], G4double& A);
+
+ private:
+
+diff --git a/source/g3tog4/src/G3EleTable.cc b/source/g3tog4/src/G3EleTable.cc
+index cecc494b201..a2f3af3d6a2 100644
+--- a/source/g3tog4/src/G3EleTable.cc
++++ b/source/g3tog4/src/G3EleTable.cc
+@@ -64,7 +64,7 @@ G3EleTable::GetEle(G4double Z){
+ }
+
+ G4int 
+-G3EleTable::parse(G4double& Z, char* name, char* sym, G4double& A){ 
++G3EleTable::parse(G4double& Z, char (&name)[20], char (&sym)[3], G4double& A){
+  G4int rc = 0;
+   if (Z>0 && Z <=_MaxEle){
+     G4int z = (G4int) Z-1;

--- a/packages/geant4/package-cache.patch
+++ b/packages/geant4/package-cache.patch
@@ -1,0 +1,48 @@
+diff --git a/cmake/Modules/G4CMakeUtilities.cmake b/cmake/Modules/G4CMakeUtilities.cmake
+index 16f7b3c8c0..84acfcd5e7 100644
+--- a/cmake/Modules/G4CMakeUtilities.cmake
++++ b/cmake/Modules/G4CMakeUtilities.cmake
+@@ -221,6 +221,21 @@ function(geant4_export_package_variables _file)
+       get_property(__var_value CACHE ${__var} PROPERTY VALUE)
+       get_property(__var_type CACHE ${__var} PROPERTY TYPE)
+       get_property(__var_help CACHE ${__var} PROPERTY HELPSTRING)
++      # Variable may not be in cache, only local (canonical case being EXPAT_LIBRARY since CMake 3.27)
++      # We still need to account for these because they may be required to be in the CACHE at least set in
++      # earlier versions.
++      # 1. Variable may not be in cache, only local (canonical case being EXPAT_LIBRARY since CMake 3.27)
++      #    We still need to account for these because they may be required to be in the CACHE at least set in
++      #    earlier versions.
++      # 2. Depending on CMake version, variable may be in cache but unitialized, here we want the local value
++      if(((NOT __var_value) AND (NOT __var_type) AND (NOT __var_help)) OR (__var_type STREQUAL "UNINITIALIZED"))
++        set(__var_value ${${__var}})
++        # TODO: set type based on whether it looks like a bool or path, but PATH almost invariably what we save
++        # Only important in cmake GUI and if value needs to be changed, which we don't if package cache is used
++        set(__var_type PATH)
++        set(__var_help "no documentation, not a cache value")
++      endif()
++
+       list(APPEND __local_build_setting "geant4_set_and_check_package_variable(${__var} \"${__var_value}\" ${__var_type} \"${__var_help}\")")
+     endforeach()
+ 
+diff --git a/cmake/Modules/G4OptionalComponents.cmake b/cmake/Modules/G4OptionalComponents.cmake
+index 7b3a1f9836..f503a2994a 100644
+--- a/cmake/Modules/G4OptionalComponents.cmake
++++ b/cmake/Modules/G4OptionalComponents.cmake
+@@ -78,6 +78,8 @@ else()
+       unset(EXPAT_FOUND)
+       unset(EXPAT_INCLUDE_DIR CACHE)
+       unset(EXPAT_LIBRARY CACHE)
++      unset(EXPAT_LIBRARY_RELEASE CACHE)
++      unset(EXPAT_LIBRARY_DEBUG CACHE)
+       message(FATAL_ERROR
+ "Detected system expat header and library:
+ EXPAT_INCLUDE_DIR = ${__badexpat_include_dir}
+@@ -88,7 +90,7 @@ Set the above CMake variables to point to an expat install of the required versi
+ 
+     # Backward compatibility for sources.cmake using the variable
+     set(EXPAT_LIBRARIES EXPAT::EXPAT)
+-    geant4_save_package_variables(EXPAT EXPAT_INCLUDE_DIR EXPAT_LIBRARY)
++    geant4_save_package_variables(EXPAT EXPAT_INCLUDE_DIR EXPAT_LIBRARY EXPAT_LIBRARY_RELEASE EXPAT_LIBRARY_DEBUG)
+   else()
+     set(EXPAT_FOUND TRUE)
+     set(GEANT4_USE_BUILTIN_EXPAT TRUE)

--- a/packages/geant4/package.py
+++ b/packages/geant4/package.py
@@ -1,0 +1,381 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+def _std_when(values):
+    return [(c.value, c.when) for v in values for c in v]
+
+
+class Geant4(CMakePackage):
+    """Geant4 is a toolkit for the simulation of the passage of particles
+    through matter. Its areas of application include high energy, nuclear
+    and accelerator physics, as well as studies in medical and space
+    science."""
+
+    homepage = "http://geant4.cern.ch/"
+    url = "https://gitlab.cern.ch/geant4/geant4/-/archive/v10.7.1/geant4-v10.7.1.tar.gz"
+
+    tags = ["hep"]
+
+    executables = ["^geant4-config$"]
+
+    maintainers("drbenmorgan", "sethrj")
+
+    version("11.4.1", sha256="99dcf5f9d4f806fb8c4fde85cb2674a42e4ca19833143464ff7efa55c1852140")
+    version("11.4.0", sha256="a6d78cf70ba46902cb74ff65d09dc2d1e46b4ab9325862f84e439f0d4ec329fb")
+    version("11.3.2", sha256="077edca6aa3b3940f351cf9a948457cad3fb117f215b88c52cce315e1a07fd7a")
+    version("11.3.1", sha256="9059da076928f25cab1ff1f35e0f611a4d7fe005e374e9b8d7f3ff2434b7af54")
+    version("11.3.0", sha256="d9d71daff8890a7b5e0e33ea9a65fe6308ad6713000b43ba6705af77078e7ead")
+    version("11.2.2", sha256="3a8d98c63fc52578f6ebf166d7dffaec36256a186d57f2520c39790367700c8d")
+    version("11.2.1", sha256="76c9093b01128ee2b45a6f4020a1bcb64d2a8141386dea4674b5ae28bcd23293")
+    version("11.2.0", sha256="9ff544739b243a24dac8f29a4e7aab4274fc0124fd4e1c4972018213dc6991ee")
+    version("11.1.3", sha256="5d9a05d4ccf8b975649eab1d615fc1b8dce5937e01ab9e795bffd04149240db6")
+    version("11.1.2", sha256="e9df8ad18c445d9213f028fd9537e174d6badb59d94bab4eeae32f665beb89af")
+    version("11.1.1", sha256="c5878634da9ba6765ce35a469b2893044f4a6598aa948733da8436cdbfeef7d2")
+    version("11.1.0", sha256="c4a23f2f502efeab56de43a4412b21f65c7ca1b0877b9bc1d7e845ee12edf70a")
+    version("11.0.4", sha256="673fb409fd1f54b65b52ddd21596f33ebb210f153730b7887a5dee7fea4d15a2")
+    version("11.0.3", sha256="1e6560b802aa84e17255b83987dfc98a1457154fb603d0f340fae978238de3e7")
+    version("11.0.2", sha256="661e1ab6f42e58910472d771e76ffd16a2b411398eed70f39808762db707799e")
+    version("11.0.1", sha256="fa76d0774346b7347b1fb1424e1c1e0502264a83e185995f3c462372994f84fa")
+    version("11.0.0", sha256="04d11d4d9041507e7f86f48eb45c36430f2b6544a74c0ccaff632ac51d9644f1")
+    version("10.7.4", sha256="7e381f8945c75388b79af98b95be31a0933641c1af8d74ab9b6cf39d5aa98317")
+    version("10.7.3", sha256="8615d93bd4178d34f31e19d67bc81720af67cdab1c8425af8523858dcddcf65b")
+    version("10.7.2", sha256="593fc85883a361487b17548ba00553501f66a811b0a79039276bb75ad59528cf")
+    version("10.7.1", sha256="2aa7cb4b231081e0a35d84c707be8f35e4edc4e97aad2b233943515476955293")
+    version("10.7.0", sha256="c991a139210c7f194720c900b149405090058c00beb5a0d2fac5c40c42a262d4")
+    version("10.6.3", sha256="bf96d6d38e6a0deabb6fb6232eb00e46153134da645715d636b9b7b4490193d3")
+    version("10.6.2", sha256="e381e04c02aeade1ed8cdd9fdbe7dcf5d6f0f9b3837a417976b839318a005dbd")
+    version("10.6.1", sha256="4fd64149ae26952672a81ce5579d3806fda4bd251d486897093ac57633a42b7e")
+    version("10.6.0", sha256="eebe6a170546064ff81ab3b00f513ccd1d4122a026514982368d503ac55a4ee4")
+    version("10.5.1", sha256="2397eb859dc4de095ff66059d8bda9f060fdc42e10469dd7890946293eeb0e39")
+    version("10.4.3", sha256="67f3bb6405a2c77e573936c2b933f5a4a33915aa379626a2eb3012009b91e1da")
+    version("10.4.0", sha256="e919b9b0a88476e00c0b18ab65d40e6a714b55ee4778f66bac32a5396c22aa74")
+    version("10.3.3", sha256="bcd36a453da44de9368d1d61b0144031a58e4b43a6d2d875e19085f2700a89d8")
+    version("10.0.4", sha256="97f3744366b00143d1eed52f8786823034bbe523f45998106f798af61d83f863")
+
+    _cxxstd_values = (
+        conditional("11", "14", when="@:10"),
+        conditional("17", when="@10.4.1:"),
+        conditional("20", when="@10.7.0:"),
+        conditional("23", when="@11:"),
+    )
+    variant(
+        "cxxstd",
+        default="11",
+        values=_cxxstd_values,
+        multi=False,
+        description="Use the specified C++ standard when building.",
+    )
+
+    variant("threads", default=True, description="Build with multithreading")
+    variant("vecgeom", default=False, description="Enable vecgeom support", when="@10.7:")
+    variant("opengl", default=False, description="Optional OpenGL support")
+    variant("x11", default=False, when="platform=linux", description="Optional X11 support")
+    variant("motif", default=False, when="+x11", description="Optional motif support")
+    variant("qt", default=False, description="Enable Qt support")
+    variant("hdf5", default=False, description="Enable HDF5 support", when="@10.4:")
+    variant("python", default=False, description="Enable Python bindings", when="@10.6.2:11.0")
+    variant("tbb", default=False, description="Use TBB as a tasking backend", when="@11:")
+    variant("timemory", default=False, description="Use TiMemory for profiling", when="@9.5:11.2")
+    variant("vtk", default=False, description="Enable VTK support", when="@11:")
+    variant("examples", default=True, description="Install examples")
+
+    # For most users, obtaining the Geant4 data via Spack will be useful; the
+    # sticky, default-enabled `+data` variant ensures that this happens.
+    # Furthermore, if this variant is enabled, Spack will automatically set the
+    # necessary environment variables to ensure that the Geant4 code runs
+    # correctly.
+    #
+    # However, the Geant4 data is also large and it is, on many machines used
+    # in HEP, already available via e.g. CVMFS. In these cases, users can save
+    # network bandwidth by using externally supplied Geant4 data. This can be
+    # done in two different ways.
+    #
+    # The first is to declare the Geant4 data directories as externals. This
+    # can be done by manually adding them to the `packages.yaml` file, e.g.:
+    #
+    # ```
+    # g4radioactivedecay:
+    #   externals:
+    #   - spec: g4radioactivedecay@5.6
+    #     prefix: <PREFIX>
+    #     buildable: False
+    # ```
+    #
+    # Where <PREFIX> is a path such that <PREFIX>/share/data/<DATASET><VERSION>
+    # exists.
+    #
+    # Alternatively, the `~data` variant can be supplied; in this case, Spack
+    # will not attempt to use the `geant4-data` spec at all. It is then
+    # essential to set up the `GEANT4_DATA_DIR` environment variable manually
+    # at runtime; see the Geant4 installation guide for more information:
+    # https://geant4-userdoc.web.cern.ch/UsersGuides/InstallationGuide/html/postinstall.html
+    variant(
+        "data", default=True, sticky=True, description="Enable downloading of the data directory"
+    )
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("cmake@3.16:", type="build", when="@11.0.0:")
+    depends_on("cmake@3.8:", type="build", when="@10.6.0:")
+    depends_on("cmake@3.5:", type="build")
+
+    for _vers in [
+        "10.0.4",
+        "10.3.3",
+        "10.4.0",
+        "10.4.3",
+        "10.5.1",
+        "10.6.0",
+        "10.6.1",
+        "10.6.2",
+        "10.6.3",
+        "10.7.0",
+        "10.7.1",
+        "10.7.2",
+        "10.7.3",
+        "10.7.4",
+        "11.0",
+        "11.1",
+        "11.2.0:11.2.1",
+        "11.2.2:11.2",
+        "11.3",
+        "11.4:",
+    ]:
+        depends_on("geant4-data@" + _vers, type="run", when="+data @" + _vers)
+
+    depends_on("expat")
+    depends_on("zlib-api")
+
+    depends_on("tbb", when="+tbb")
+    depends_on("timemory@3.2:", when="+timemory")
+    depends_on("vtk@8.2:", when="+vtk")
+
+    # Python, with boost requirement dealt with in cxxstd section
+    depends_on("python@3:", when="+python")
+    extends("python", when="+python")
+
+    # CLHEP version requirements to be reviewed
+    depends_on("clhep@2.4.7.2:", when="@11.4:")
+    depends_on("clhep@2.4.7.1:", when="@11.3:")
+    depends_on("clhep@2.4.6.0:", when="@11.1:")
+    depends_on("clhep@2.4.5.1:", when="@11.0.0:")
+    depends_on("clhep@2.4.4.0:", when="@10.7.0:")
+    depends_on("clhep@2.3.3.0:", when="@10.3:10.6")
+    depends_on("clhep@2.1.2.3", when="@:10.2")
+
+    # Vecgeom specific versions for each Geant4 version
+    with when("+vecgeom"):
+        depends_on("vecgeom@1.2.6:", when="@11.2:")
+        depends_on("vecgeom@1.2.0:", when="@11.1")
+        depends_on("vecgeom@1.1.18:1.1", when="@11.0.0:11.0")
+        depends_on("vecgeom@1.1.8:1.1", when="@10.7.0:10.7")
+
+    with when("+hdf5"):
+        depends_on("hdf5 +threadsafe")
+
+    for _std, _when in _std_when(_cxxstd_values):
+        depends_on(f"clhep cxxstd={_std}", when=f"{_when} cxxstd={_std}")
+        depends_on(f"vecgeom cxxstd={_std}", when=f"{_when} +vecgeom cxxstd={_std}")
+
+        # Spack only supports Xerces-c 3 and above, so no version req
+        depends_on(f"xerces-c netaccessor=curl cxxstd={_std}", when=f"{_when} cxxstd={_std}")
+
+        # Boost.python, conflict handled earlier
+        depends_on(f"boost@1.70: +python cxxstd={_std}", when=f"{_when} +python cxxstd={_std}")
+
+    # Visualization driver dependencies
+    depends_on("gl", when="+opengl")
+    depends_on("glu", when="+opengl")
+    depends_on("glx", when="+opengl+x11")
+    depends_on("libx11", when="+x11")
+    depends_on("libxmu", when="+x11")
+    depends_on("motif", when="+motif")
+    with when("+qt"):
+        depends_on("qmake")
+        with when("^[virtuals=qmake] qt-base"):
+            depends_on("qt-base +accessibility +gui +opengl")
+        with when("^[virtuals=qmake] qt"):
+            depends_on("qt@5: +opengl")
+            depends_on("qt@5.9:", when="@11.2:11.3")
+    conflicts("@11.4: ^[virtuals=qmake] qt", msg="Qt5 not supported in 11.4 and later")
+    conflicts("@:11.1 ^[virtuals=qmake] qt-base", msg="Qt6 not supported before 11.2")
+    conflicts("+opengl", when="platform=darwin", msg="OpenGL requires Linux or Windows")
+
+    # CMAKE PROBLEMS #
+    # As released, 10.0.4 has inconsistently capitalised filenames
+    # in the cmake files; this patch also enables cxxstd 14
+    patch("geant4-10.0.4.patch", when="@10.0.4")
+    # Build failure on clang 15, ubuntu 22: see Geant4 problem report #2444
+    # fixed by ascii-V10-07-03
+    patch("geant4-10.6.patch", when="@10.0:10.6")
+    # Enable "17" cxxstd option in CMake (2 different filenames)
+    patch("geant4-10.3-cxx17-cmake.patch", when="@10.3 cxxstd=17")
+    patch("geant4-10.4-cxx17-cmake.patch", when="@10.4:10.4.2 cxxstd=17")
+    # Fix exported cmake: https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2556
+    patch("package-cache.patch", when="@10.7.0:11.1.2^cmake@3.17:")
+
+    # BUILD ERRORS #
+    # Fix C++17: add -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES C++ flag
+    patch("geant4-10.4.3-cxx17-removed-features.patch", when="@10.4.3 cxxstd=17")
+    # Fix C++20: build error due to removed-in-C++20 `ostream::operator>>(char*)`
+    # (different, simpler approach than upstream Geant4 changes)
+    patch("geant4-10.7-cxx20-g3tog4.patch", when="@:10.7 cxxstd=20")
+    # Fix member field typo in g4tools wroot: https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2640
+    patch("columns-10.patch", when="@10.4:10")
+    patch("columns-11.patch", when="@11:11.2.2")
+    # Fix navigation errors with twisted tubes: https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2619
+    patch("twisted-tubes.patch", when="@11.2.0:11.2.2")
+
+    # NVHPC: "thread-local declaration follows non-thread-local declaration"
+    conflicts("%nvhpc", when="+threads")
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        # We already get the correct format
+        return output.strip()
+
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        variants = []
+        cxxstd = Executable(exes[0])("--cxxstd", output=str, error=str)
+        # output will be something like c++17, we only want the number
+        variants.append("cxxstd={}".format(cxxstd[-3:]))
+
+        def _has_feature(feature):
+            res = Executable(exes[0])("--has-feature", feature, output=str, error=str)
+            return res.strip() == "yes"
+
+        def _add_variant(feature, variant):
+            """Helper to determine whether a given feature is present and append the
+            corresponding variant to the list"""
+            if _has_feature(feature):
+                variants.append("+{}".format(variant))
+            else:
+                variants.append("~{}".format(variant))
+
+        _add_variant("qt", "qt")
+        _add_variant("motif", "motif")
+        _add_variant("multithreading", "threads")
+        _add_variant("usolids", "vecgeom")
+
+        if _has_feature("opengl-x11"):
+            variants.append("+opengl")
+            variants.append("+x11")
+        else:
+            variants.append("~opengl")
+            # raytracer-x11 could still lead to the activation of the x11
+            # variant without +opengl
+            _add_variant("raytracer-x11", "x11")
+
+        # TODO: The following variants cannot be determined from geant4-config.
+        # - python
+        # - tbb
+        # - vtk
+        # Should we have a (version dependent) warning message for these?
+
+        return " ".join(variants)
+
+    def flag_handler(self, name, flags):
+        spec = self.spec
+        if name == "cxxflags":
+            if spec.satisfies("%nvhpc"):
+                # error: excessive recursion at instantiation of class
+                # "G4Number<191>" (G4CTCounter.hh)
+                flags.append("-Wc,--pending_instantiations=256")
+                return (None, flags, None)
+        return (flags, None, None)
+
+    def cmake_args(self):
+        spec = self.spec
+
+        # Core options
+        options = [
+            self.define("GEANT4_USE_SYSTEM_CLHEP", True),
+            self.define("GEANT4_USE_SYSTEM_EXPAT", True),
+            self.define("GEANT4_USE_SYSTEM_ZLIB", True),
+            self.define("GEANT4_USE_G3TOG4", True),
+            self.define("GEANT4_USE_GDML", True),
+            self.define("XERCESC_ROOT_DIR", spec["xerces-c"].prefix),
+        ]
+
+        # Use the correct C++ standard option for the requested version
+        if spec.version >= Version("11.0"):
+            options.append(self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"))
+        elif spec.version >= Version("10.3"):
+            options.append(self.define_from_variant("GEANT4_BUILD_CXXSTD", "cxxstd"))
+        else:
+            cxxstd = spec.variants["cxxstd"].value
+            options.append(self.define("GEANT4_BUILD_CXXSTD", f"c++{cxxstd}"))
+
+        if spec.version >= Version("10.6"):
+            # When building a downstream library/app outside of Spack, make
+            # sure that Geant4's dependencies are found
+            options.append(self.define("GEANT4_INSTALL_PACKAGE_CACHE", True))
+
+        # Multithreading
+        options.append(self.define_from_variant("GEANT4_BUILD_MULTITHREADED", "threads"))
+        options.append(self.define_from_variant("GEANT4_USE_TBB", "tbb"))
+
+        if spec.satisfies("+threads"):
+            # Locked at global-dynamic to allow use cases that load the
+            # geant4 libs at application runtime
+            options.append(self.define("GEANT4_BUILD_TLS_MODEL", "global-dynamic"))
+
+        # Profiling
+        options.append(self.define_from_variant("GEANT4_USE_TIMEMORY", "timemory"))
+
+        # Never install the data with geant4, but point to the dependent
+        # geant4-data's install directory to correctly set up the
+        # Geant4Config.cmake values for Geant4_DATASETS .
+        options.append(self.define("GEANT4_INSTALL_DATA", False))
+        if spec.satisfies("+data"):
+            options.append(self.define("GEANT4_INSTALL_DATADIR", self.datadir))
+            variants = self.spec["geant4-data"].variants
+            for v in ["tendl", "nudexlib", "urrpt"]:
+                if v in variants:
+                    # Inform Geant4 whether this optional dataset is in use
+                    # so that it's exported to Geant4_DATASET_DESCRIPTIONS
+                    options.append(
+                        self.define("GEANT4_INSTALL_DATASETS_" + v.upper(), variants[v].value)
+                    )
+
+        # Vecgeom
+        options.append(self.define_from_variant("GEANT4_USE_USOLIDS", "vecgeom"))
+        if spec.satisfies("+vecgeom"):
+            options.append(self.define("USolids_DIR", spec["vecgeom"].prefix.lib.CMake.USolids))
+
+        # Visualization options
+        if spec.satisfies("+x11 +opengl"):
+            options.append(self.define("GEANT4_USE_OPENGL_X11", True))
+        if spec.satisfies("platform=windows"):
+            options.append(self.define_from_variant("GEANT4_USE_OPENGL_WIN32", "opengl"))
+        options.append(self.define_from_variant("GEANT4_USE_XM", "motif"))
+        options.append(self.define_from_variant("GEANT4_USE_RAYTRACER_X11", "x11"))
+
+        options.append(self.define_from_variant("GEANT4_USE_QT", "qt"))
+        if spec.satisfies("+qt"):
+            if spec.satisfies("^[virtuals=qmake] qt-base"):
+                options.append(self.define("GEANT4_USE_QT_QT6", True))
+            options.append(self.define("QT_QMAKE_EXECUTABLE", spec["qmake"].prefix.bin.qmake))
+
+        options.append(self.define_from_variant("GEANT4_USE_HDF5", "hdf5"))
+        options.append(self.define_from_variant("GEANT4_USE_VTK", "vtk"))
+        options.append(self.define_from_variant("GEANT4_USE_PYTHON", "python"))
+        options.append(self.define_from_variant("GEANT4_INSTALL_EXAMPLES", "examples"))
+
+        return options
+
+    @property
+    def datadir(self):
+        dataspec = self.spec["geant4-data"]
+        return join_path(
+            dataspec.prefix.share, "{0}-{1}".format(dataspec.name, dataspec.version.dotted)
+        )

--- a/packages/geant4/package.py
+++ b/packages/geant4/package.py
@@ -62,7 +62,12 @@ class Geant4(CMakePackage):
         conditional("11", "14", when="@:10"),
         conditional("17", when="@10.4.1:"),
         conditional("20", when="@10.7.0:"),
-        conditional("23", when="@11:"),
+        # cxxstd=23 is intentionally omitted: this overlay ships a newer geant4
+        # than the clhep in the pinned spack-packages commit, and that clhep does
+        # not define cxxstd=23. Keeping the 23 conditional makes the propagation
+        # loop below emit `depends_on("clhep cxxstd=23")`, which fails to load
+        # ("invalid values for variant 'cxxstd' in package clhep: '23'"). The
+        # whole stack is pinned to cxxstd=20, so 23 is unused anyway.
     )
     variant(
         "cxxstd",

--- a/packages/geant4/twisted-tubes.patch
+++ b/packages/geant4/twisted-tubes.patch
@@ -1,0 +1,875 @@
+diff --git a/source/geometry/solids/specific/include/G4TwistedTubs.hh b/source/geometry/solids/specific/include/G4TwistedTubs.hh
+index b8be4e629da8edb87c8e7fdcb12ae243fbb910e4..e6ca127646f1aa1f60b04b5100123ccfff9b698c 100644
+--- a/source/geometry/solids/specific/include/G4TwistedTubs.hh
++++ b/source/geometry/solids/specific/include/G4TwistedTubs.hh
+@@ -226,109 +226,6 @@ class G4TwistedTubs : public G4VSolid
+     mutable G4bool fRebuildPolyhedron = false;
+     mutable G4Polyhedron* fpPolyhedron = nullptr; // polyhedron for vis
+ 
+-    class LastState              // last Inside result
+-    {
+-      public:
+-        LastState()
+-        {
+-          p.set(kInfinity,kInfinity,kInfinity);
+-          inside = kOutside;
+-        }
+-        ~LastState()= default;
+-        LastState(const LastState& r)  = default;
+-        LastState& operator=(const LastState& r)
+-        {
+-          if (this == &r)  { return *this; }
+-          p = r.p; inside = r.inside;
+-          return *this;
+-        }
+-      public:
+-        G4ThreeVector p;
+-        EInside       inside;
+-    };
+-              
+-    class LastVector             // last SurfaceNormal result
+-    {
+-      public:
+-        LastVector()
+-        {
+-          p.set(kInfinity,kInfinity,kInfinity);
+-          vec.set(kInfinity,kInfinity,kInfinity);
+-          surface = new G4VTwistSurface*[1];
+-        }
+-        ~LastVector()
+-        {
+-          delete [] surface;
+-        }
+-        LastVector(const LastVector& r) : p(r.p), vec(r.vec)
+-        {
+-          surface = new G4VTwistSurface*[1];
+-          surface[0] = r.surface[0];
+-        }
+-        LastVector& operator=(const LastVector& r)
+-        {
+-          if (&r == this)  { return *this; }
+-          p = r.p; vec = r.vec;
+-          delete [] surface; surface = new G4VTwistSurface*[1];
+-          surface[0] = r.surface[0];
+-          return *this;
+-        }
+-      public:
+-        G4ThreeVector   p;
+-        G4ThreeVector   vec;
+-       G4VTwistSurface **surface;
+-     };
+-
+-    class LastValue              // last G4double value
+-    {
+-      public:
+-        LastValue()
+-        {
+-          p.set(kInfinity,kInfinity,kInfinity);
+-          value = DBL_MAX;
+-        }
+-        ~LastValue()= default;
+-        LastValue(const LastValue& r)  = default;
+-        LastValue& operator=(const LastValue& r)
+-        {
+-          if (this == &r)  { return *this; }
+-          p = r.p; value = r.value;
+-          return *this;
+-        }
+-      public:
+-        G4ThreeVector p;
+-        G4double      value;
+-    };
+-              
+-    class LastValueWithDoubleVector   // last G4double value
+-    {
+-      public:
+-        LastValueWithDoubleVector()
+-        {
+-          p.set(kInfinity,kInfinity,kInfinity);
+-          vec.set(kInfinity,kInfinity,kInfinity);
+-          value = DBL_MAX;
+-        }
+-        ~LastValueWithDoubleVector()= default;
+-        LastValueWithDoubleVector(const LastValueWithDoubleVector& r) = default;
+-        LastValueWithDoubleVector& operator=(const LastValueWithDoubleVector& r)
+-        {
+-          if (this == &r)  { return *this; }
+-          p = r.p; vec = r.vec; value = r.value;
+-          return *this;
+-        }
+-      public:
+-        G4ThreeVector p;
+-        G4ThreeVector vec;
+-        G4double      value;
+-    };
+-              
+-    LastState    fLastInside;
+-    LastVector   fLastNormal;
+-    LastValue    fLastDistanceToIn;
+-    LastValue    fLastDistanceToOut;
+-    LastValueWithDoubleVector   fLastDistanceToInWithV;
+-    LastValueWithDoubleVector   fLastDistanceToOutWithV;
+ };
+ 
+ //=====================================================================
+diff --git a/source/geometry/solids/specific/include/G4VTwistedFaceted.hh b/source/geometry/solids/specific/include/G4VTwistedFaceted.hh
+index 3d58ba0b242bb4ddc900a3bf0dfd404252cc42e3..6c412c390d0bf780abfe68fdaa89ea76e3264f7c 100644
+--- a/source/geometry/solids/specific/include/G4VTwistedFaceted.hh
++++ b/source/geometry/solids/specific/include/G4VTwistedFaceted.hh
+@@ -190,110 +190,6 @@ class G4VTwistedFaceted: public G4VSolid
+     G4VTwistSurface* fSide180 ;  // Twisted Side at phi = 180 deg
+     G4VTwistSurface* fSide270 ;  // Twisted Side at phi = 270 deg
+ 
+-  private:
+-
+-    class LastState              // last Inside result
+-    {
+-      public:
+-        LastState()
+-        {
+-          p.set(kInfinity,kInfinity,kInfinity); inside = kOutside;
+-        }
+-        ~LastState()= default;
+-        LastState(const LastState& r)  = default;
+-        LastState& operator=(const LastState& r)
+-        {
+-          if (this == &r)  { return *this; }
+-          p = r.p; inside = r.inside;
+-          return *this;
+-        }
+-      public:
+-        G4ThreeVector p;
+-        EInside       inside;
+-    };
+-
+-    class LastVector             // last SurfaceNormal result
+-    {
+-      public:
+-        LastVector()
+-        {
+-          p.set(kInfinity,kInfinity,kInfinity);
+-          vec.set(kInfinity,kInfinity,kInfinity);
+-          surface = new G4VTwistSurface*[1];
+-        }
+-        ~LastVector()
+-        {
+-          delete [] surface;
+-        }
+-        LastVector(const LastVector& r) : p(r.p), vec(r.vec)
+-        {
+-          surface = new G4VTwistSurface*[1];
+-          surface[0] = r.surface[0];
+-        }
+-        LastVector& operator=(const LastVector& r)
+-        {
+-          if (&r == this)  { return *this; }
+-          p = r.p; vec = r.vec;
+-          delete [] surface; surface = new G4VTwistSurface*[1];
+-          surface[0] = r.surface[0];
+-          return *this;
+-        }
+-      public:
+-        G4ThreeVector   p;
+-        G4ThreeVector   vec;
+-        G4VTwistSurface **surface;
+-    };
+-
+-    class LastValue              // last G4double value
+-    {
+-      public:
+-        LastValue()
+-        {
+-          p.set(kInfinity,kInfinity,kInfinity);
+-          value = DBL_MAX;
+-        }
+-        ~LastValue()= default;
+-        LastValue(const LastValue& r)  = default;
+-        LastValue& operator=(const LastValue& r)
+-        {
+-          if (this == &r)  { return *this; }
+-          p = r.p; value = r.value;
+-          return *this;
+-        }
+-      public:
+-        G4ThreeVector p;
+-        G4double      value;
+-    };
+-
+-    class LastValueWithDoubleVector   // last G4double value
+-    {
+-      public:
+-        LastValueWithDoubleVector()
+-        {
+-          p.set(kInfinity,kInfinity,kInfinity);
+-          vec.set(kInfinity,kInfinity,kInfinity);
+-          value = DBL_MAX;
+-        }
+-        ~LastValueWithDoubleVector()= default;
+-        LastValueWithDoubleVector(const LastValueWithDoubleVector& r) = default;
+-        LastValueWithDoubleVector& operator=(const LastValueWithDoubleVector& r)
+-        {
+-          if (this == &r)  { return *this; }
+-          p = r.p; vec = r.vec; value = r.value;
+-          return *this;
+-        }
+-      public:
+-        G4ThreeVector p;
+-        G4ThreeVector vec;
+-        G4double      value;
+-    };
+-
+-    LastState    fLastInside;
+-    LastVector   fLastNormal;
+-    LastValue    fLastDistanceToIn;
+-    LastValue    fLastDistanceToOut;
+-    LastValueWithDoubleVector   fLastDistanceToInWithV;
+-    LastValueWithDoubleVector   fLastDistanceToOutWithV;
+ };
+ 
+ //=====================================================================
+diff --git a/source/geometry/solids/specific/src/G4TwistedTubs.cc b/source/geometry/solids/specific/src/G4TwistedTubs.cc
+index 60dea7239081e58af194ecbe6cdeb33781a069b3..e8e414fabd74ecd1e2ed83ee8c072b932e9ae6dd 100644
+--- a/source/geometry/solids/specific/src/G4TwistedTubs.cc
++++ b/source/geometry/solids/specific/src/G4TwistedTubs.cc
+@@ -56,6 +56,7 @@ namespace
+   G4Mutex polyhedronMutex = G4MUTEX_INITIALIZER;
+ }
+ 
++
+ //=====================================================================
+ //* constructors ------------------------------------------------------
+ 
+@@ -223,12 +224,7 @@ G4TwistedTubs::G4TwistedTubs(const G4TwistedTubs& rhs)
+     fTanOuterStereo2(rhs.fTanOuterStereo2),
+     fLowerEndcap(nullptr), fUpperEndcap(nullptr), fLatterTwisted(nullptr), fFormerTwisted(nullptr),
+     fInnerHype(nullptr), fOuterHype(nullptr),
+-    fCubicVolume(rhs.fCubicVolume), fSurfaceArea(rhs.fSurfaceArea),
+-    fLastInside(rhs.fLastInside), fLastNormal(rhs.fLastNormal),
+-    fLastDistanceToIn(rhs.fLastDistanceToIn),
+-    fLastDistanceToOut(rhs.fLastDistanceToOut),
+-    fLastDistanceToInWithV(rhs.fLastDistanceToInWithV),
+-    fLastDistanceToOutWithV(rhs.fLastDistanceToOutWithV)
++    fCubicVolume(rhs.fCubicVolume), fSurfaceArea(rhs.fSurfaceArea)
+ {
+   for (auto i=0; i<2; ++i)
+   {
+@@ -268,11 +264,6 @@ G4TwistedTubs& G4TwistedTubs::operator = (const G4TwistedTubs& rhs)
+    fLowerEndcap= fUpperEndcap= fLatterTwisted= fFormerTwisted= nullptr;
+    fInnerHype= fOuterHype= nullptr;
+    fCubicVolume= rhs.fCubicVolume; fSurfaceArea= rhs.fSurfaceArea;
+-   fLastInside= rhs.fLastInside; fLastNormal= rhs.fLastNormal;
+-   fLastDistanceToIn= rhs.fLastDistanceToIn;
+-   fLastDistanceToOut= rhs.fLastDistanceToOut;
+-   fLastDistanceToInWithV= rhs.fLastDistanceToInWithV;
+-   fLastDistanceToOutWithV= rhs.fLastDistanceToOutWithV;
+  
+    for (auto i=0; i<2; ++i)
+    {
+@@ -381,44 +372,32 @@ EInside G4TwistedTubs::Inside(const G4ThreeVector& p) const
+    // G4Timer timer(timerid, "G4TwistedTubs", "Inside");
+    // timer.Start();
+ 
+-   G4ThreeVector *tmpp;
+-   EInside       *tmpinside;
+-   if (fLastInside.p == p)
+-   {
+-     return fLastInside.inside;
+-   }
+-   else
+-   {
+-      tmpp      = const_cast<G4ThreeVector*>(&(fLastInside.p));
+-      tmpinside = const_cast<EInside*>(&(fLastInside.inside));
+-      tmpp->set(p.x(), p.y(), p.z());
+-   }
+    
+    EInside  outerhypearea = ((G4TwistTubsHypeSide *)fOuterHype)->Inside(p);
+    G4double innerhyperho  = ((G4TwistTubsHypeSide *)fInnerHype)->GetRhoAtPZ(p);
+    G4double distanceToOut = p.getRho() - innerhyperho; // +ve: inside
+-
++   EInside       tmpinside;
+    if ((outerhypearea == kOutside) || (distanceToOut < -halftol))
+    {
+-      *tmpinside = kOutside;
++      tmpinside = kOutside;
+    }
+    else if (outerhypearea == kSurface)
+    {
+-      *tmpinside = kSurface;
++      tmpinside = kSurface;
+    }
+    else
+    {
+       if (distanceToOut <= halftol)
+       {
+-         *tmpinside = kSurface;
++         tmpinside = kSurface;
+       }
+       else
+       {
+-         *tmpinside = kInside;
++         tmpinside = kInside;
+       }
+    }
+ 
+-   return fLastInside.inside;
++   return tmpinside;
+ }
+ 
+ //=====================================================================
+@@ -433,14 +412,6 @@ G4ThreeVector G4TwistedTubs::SurfaceNormal(const G4ThreeVector& p) const
+    // Which of the three or four surfaces are we closest to?
+    //
+ 
+-   if (fLastNormal.p == p)
+-   {
+-      return fLastNormal.vec;
+-   }    
+-   auto tmpp       = const_cast<G4ThreeVector*>(&(fLastNormal.p));
+-   auto tmpnormal  = const_cast<G4ThreeVector*>(&(fLastNormal.vec));
+-   auto tmpsurface = const_cast<G4VTwistSurface**>(fLastNormal.surface);
+-   tmpp->set(p.x(), p.y(), p.z());
+ 
+    G4double      distance = kInfinity;
+ 
+@@ -466,10 +437,7 @@ G4ThreeVector G4TwistedTubs::SurfaceNormal(const G4ThreeVector& p) const
+       }
+    }
+ 
+-   tmpsurface[0] = surfaces[besti];
+-   *tmpnormal = tmpsurface[0]->GetNormal(bestxx, true);
+-   
+-   return fLastNormal.vec;
++  return surfaces[besti]->GetNormal(bestxx, true);
+ }
+ 
+ //=====================================================================
+@@ -485,26 +453,6 @@ G4double G4TwistedTubs::DistanceToIn (const G4ThreeVector& p,
+    // The function returns kInfinity if no intersection or
+    // just grazing within tolerance.
+ 
+-   //
+-   // checking last value
+-   //
+-   
+-   G4ThreeVector* tmpp;
+-   G4ThreeVector* tmpv;
+-   G4double* tmpdist;
+-   if ((fLastDistanceToInWithV.p == p) && (fLastDistanceToInWithV.vec == v))
+-   {
+-     return fLastDistanceToIn.value;
+-   }
+-   else
+-   {
+-      tmpp    = const_cast<G4ThreeVector*>(&(fLastDistanceToInWithV.p));
+-      tmpv    = const_cast<G4ThreeVector*>(&(fLastDistanceToInWithV.vec));
+-      tmpdist = const_cast<G4double*>(&(fLastDistanceToInWithV.value));
+-      tmpp->set(p.x(), p.y(), p.z());
+-      tmpv->set(v.x(), v.y(), v.z());
+-   }
+-
+    //
+    // Calculate DistanceToIn(p,v)
+    //
+@@ -524,8 +472,7 @@ G4double G4TwistedTubs::DistanceToIn (const G4ThreeVector& p,
+        G4ThreeVector normal = SurfaceNormal(p);
+        if (normal*v < 0)
+        {
+-         *tmpdist = 0.;
+-         return fLastDistanceToInWithV.value;
++         return 0;
+        } 
+      }
+    }
+@@ -557,9 +504,7 @@ G4double G4TwistedTubs::DistanceToIn (const G4ThreeVector& p,
+          bestxx = xx;
+       }
+    }
+-   *tmpdist = distance;
+-
+-   return fLastDistanceToInWithV.value;
++   return distance;
+ }
+  
+ //=====================================================================
+@@ -570,23 +515,6 @@ G4double G4TwistedTubs::DistanceToIn (const G4ThreeVector& p) const
+    // DistanceToIn(p):
+    // Calculate distance to surface of shape from `outside',
+    // allowing for tolerance
+-   
+-   //
+-   // checking last value
+-   //
+-   
+-   G4ThreeVector* tmpp;
+-   G4double* tmpdist;
+-   if (fLastDistanceToIn.p == p)
+-   {
+-     return fLastDistanceToIn.value;
+-   }
+-   else
+-   {
+-      tmpp    = const_cast<G4ThreeVector*>(&(fLastDistanceToIn.p));
+-      tmpdist = const_cast<G4double*>(&(fLastDistanceToIn.value));
+-      tmpp->set(p.x(), p.y(), p.z());
+-   }
+ 
+    //
+    // Calculate DistanceToIn(p) 
+@@ -600,8 +528,7 @@ G4double G4TwistedTubs::DistanceToIn (const G4ThreeVector& p) const
+       {}
+       case (kSurface) :
+       {
+-         *tmpdist = 0.;
+-         return fLastDistanceToIn.value;
++         return 0;
+       }
+       case (kOutside) :
+       {
+@@ -628,8 +555,7 @@ G4double G4TwistedTubs::DistanceToIn (const G4ThreeVector& p) const
+                bestxx = xx;
+             }
+          }
+-         *tmpdist = distance;
+-         return fLastDistanceToIn.value;
++         return distance;
+       }
+       default :
+       {
+@@ -656,32 +582,11 @@ G4double G4TwistedTubs::DistanceToOut( const G4ThreeVector& p,
+    // The function returns kInfinity if no intersection or
+    // just grazing within tolerance.
+ 
+-   //
+-   // checking last value
+-   //
+-   
+-   G4ThreeVector* tmpp;
+-   G4ThreeVector* tmpv;
+-   G4double* tmpdist;
+-   if ((fLastDistanceToOutWithV.p == p) && (fLastDistanceToOutWithV.vec == v) )
+-   {
+-     return fLastDistanceToOutWithV.value;
+-   }
+-   else
+-   {
+-      tmpp    = const_cast<G4ThreeVector*>(&(fLastDistanceToOutWithV.p));
+-      tmpv    = const_cast<G4ThreeVector*>(&(fLastDistanceToOutWithV.vec));
+-      tmpdist = const_cast<G4double*>(&(fLastDistanceToOutWithV.value));
+-      tmpp->set(p.x(), p.y(), p.z());
+-      tmpv->set(v.x(), v.y(), v.z());
+-   }
+-
+    //
+    // Calculate DistanceToOut(p,v)
+    //
+    
+    EInside currentside = Inside(p);
+-
+    if (currentside == kOutside)
+    {
+    }
+@@ -693,16 +598,14 @@ G4double G4TwistedTubs::DistanceToOut( const G4ThreeVector& p,
+        // If the particle is exiting from the volume, return 0.
+        //
+        G4ThreeVector normal = SurfaceNormal(p);
+-       G4VTwistSurface *blockedsurface = fLastNormal.surface[0];
+        if (normal*v > 0)
+        {
+          if (calcNorm)
+          {
+-           *norm = (blockedsurface->GetNormal(p, true));
+-           *validNorm = blockedsurface->IsValidNorm();
++           *norm = normal;
++           *validNorm = true;
+          }
+-         *tmpdist = 0.;
+-         return fLastDistanceToOutWithV.value;
++         return 0;
+        }
+      }
+    }
+@@ -746,9 +649,7 @@ G4double G4TwistedTubs::DistanceToOut( const G4ThreeVector& p,
+       }
+    }
+ 
+-   *tmpdist = distance;
+-
+-   return fLastDistanceToOutWithV.value;
++   return distance;
+ }
+ 
+ 
+@@ -761,23 +662,6 @@ G4double G4TwistedTubs::DistanceToOut( const G4ThreeVector& p ) const
+    // Calculate distance to surface of shape from `inside', 
+    // allowing for tolerance
+ 
+-   //
+-   // checking last value
+-   //
+-   
+-   G4ThreeVector* tmpp;
+-   G4double* tmpdist;
+-   if (fLastDistanceToOut.p == p)
+-   {
+-      return fLastDistanceToOut.value;
+-   }
+-   else
+-   {
+-      tmpp    = const_cast<G4ThreeVector*>(&(fLastDistanceToOut.p));
+-      tmpdist = const_cast<G4double*>(&(fLastDistanceToOut.value));
+-      tmpp->set(p.x(), p.y(), p.z());
+-   }
+-   
+    //
+    // Calculate DistanceToOut(p)
+    //
+@@ -791,8 +675,7 @@ G4double G4TwistedTubs::DistanceToOut( const G4ThreeVector& p ) const
+       }
+       case (kSurface) :
+       {
+-        *tmpdist = 0.;
+-         return fLastDistanceToOut.value;
++         return 0;
+       }
+       case (kInside) :
+       {
+@@ -819,9 +702,7 @@ G4double G4TwistedTubs::DistanceToOut( const G4ThreeVector& p ) const
+                bestxx = xx;
+             }
+          }
+-         *tmpdist = distance;
+-   
+-         return fLastDistanceToOut.value;
++         return distance;
+       }
+       default :
+       {
+diff --git a/source/geometry/solids/specific/src/G4VTwistedFaceted.cc b/source/geometry/solids/specific/src/G4VTwistedFaceted.cc
+index b8d5c74539453e7a5a5f99623c5e4c9477ff8014..5a524e3398509d340955028835cdf6d52b70b66b 100644
+--- a/source/geometry/solids/specific/src/G4VTwistedFaceted.cc
++++ b/source/geometry/solids/specific/src/G4VTwistedFaceted.cc
+@@ -54,6 +54,7 @@ namespace
+   G4Mutex polyhedronMutex = G4MUTEX_INITIALIZER;
+ }
+ 
++
+ //=====================================================================
+ //* constructors ------------------------------------------------------
+ 
+@@ -222,12 +223,7 @@ G4VTwistedFaceted::G4VTwistedFaceted(const G4VTwistedFaceted& rhs)
+     fDx3(rhs.fDx3), fDx4(rhs.fDx4), fDz(rhs.fDz), fDx(rhs.fDx), fDy(rhs.fDy),
+     fAlph(rhs.fAlph), fTAlph(rhs.fTAlph), fdeltaX(rhs.fdeltaX),
+     fdeltaY(rhs.fdeltaY), fPhiTwist(rhs.fPhiTwist), fLowerEndcap(nullptr),
+-    fUpperEndcap(nullptr), fSide0(nullptr), fSide90(nullptr), fSide180(nullptr), fSide270(nullptr),
+-    fLastInside(rhs.fLastInside), fLastNormal(rhs.fLastNormal),
+-    fLastDistanceToIn(rhs.fLastDistanceToIn),
+-    fLastDistanceToOut(rhs.fLastDistanceToOut),
+-    fLastDistanceToInWithV(rhs.fLastDistanceToInWithV),
+-    fLastDistanceToOutWithV(rhs.fLastDistanceToOutWithV)
++    fUpperEndcap(nullptr), fSide0(nullptr), fSide90(nullptr), fSide180(nullptr), fSide270(nullptr)
+ {
+   CreateSurfaces();
+ }
+@@ -257,11 +253,6 @@ G4VTwistedFaceted& G4VTwistedFaceted::operator = (const G4VTwistedFaceted& rhs)
+    fCubicVolume= rhs.fCubicVolume; fSurfaceArea= rhs.fSurfaceArea;
+    fRebuildPolyhedron = false;
+    delete fpPolyhedron; fpPolyhedron = nullptr;
+-   fLastInside= rhs.fLastInside; fLastNormal= rhs.fLastNormal;
+-   fLastDistanceToIn= rhs.fLastDistanceToIn;
+-   fLastDistanceToOut= rhs.fLastDistanceToOut;
+-   fLastDistanceToInWithV= rhs.fLastDistanceToInWithV;
+-   fLastDistanceToOutWithV= rhs.fLastDistanceToOutWithV;
+  
+    CreateSurfaces();
+ 
+@@ -347,20 +338,7 @@ G4VTwistedFaceted::CalculateExtent( const EAxis              pAxis,
+ EInside G4VTwistedFaceted::Inside(const G4ThreeVector& p) const
+ {
+ 
+-   G4ThreeVector *tmpp;
+-   EInside       *tmpin;
+-   if (fLastInside.p == p)
+-   {
+-     return fLastInside.inside;
+-   }
+-   else
+-   {
+-      tmpp      = const_cast<G4ThreeVector*>(&(fLastInside.p));
+-      tmpin     = const_cast<EInside*>(&(fLastInside.inside));
+-      tmpp->set(p.x(), p.y(), p.z());
+-   }
+-
+-   *tmpin = kOutside ;
++   EInside tmpin = kOutside ;
+ 
+    G4double phi = p.z()/(2*fDz) * fPhiTwist ;  // rotate the point to z=0
+    G4double cphi = std::cos(-phi) ;
+@@ -414,13 +392,13 @@ EInside G4VTwistedFaceted::Inside(const G4ThreeVector& p) const
+     if ( posy <= yMax - kCarTolerance*0.5
+       && posy >= yMin + kCarTolerance*0.5 )
+     {
+-      if      (std::fabs(posz) <= fDz - kCarTolerance*0.5 ) *tmpin = kInside ;
+-      else if (std::fabs(posz) <= fDz + kCarTolerance*0.5 ) *tmpin = kSurface ;
++      if      (std::fabs(posz) <= fDz - kCarTolerance*0.5 ) tmpin = kInside ;
++      else if (std::fabs(posz) <= fDz + kCarTolerance*0.5 ) tmpin = kSurface ;
+     }
+     else if ( posy <= yMax + kCarTolerance*0.5
+            && posy >= yMin - kCarTolerance*0.5 )
+     {
+-      if (std::fabs(posz) <= fDz + kCarTolerance*0.5 ) *tmpin = kSurface ;
++      if (std::fabs(posz) <= fDz + kCarTolerance*0.5 ) tmpin = kSurface ;
+     }
+   }
+   else if ( posx <= xMax + kCarTolerance*0.5
+@@ -429,15 +407,15 @@ EInside G4VTwistedFaceted::Inside(const G4ThreeVector& p) const
+     if ( posy <= yMax + kCarTolerance*0.5
+       && posy >= yMin - kCarTolerance*0.5 )
+     {
+-      if (std::fabs(posz) <= fDz + kCarTolerance*0.5) *tmpin = kSurface ;
++      if (std::fabs(posz) <= fDz + kCarTolerance*0.5) tmpin = kSurface ;
+     }
+   }
+ 
+ #ifdef G4TWISTDEBUG
+-  G4cout << "inside = " << fLastInside.inside << G4endl ;
++  G4cout << "inside = " << tmpin << G4endl ;
+ #endif
+ 
+-  return fLastInside.inside;
++  return tmpin;
+ 
+ }
+ 
+@@ -454,15 +432,6 @@ G4ThreeVector G4VTwistedFaceted::SurfaceNormal(const G4ThreeVector& p) const
+    // Which of the three or four surfaces are we closest to?
+    //
+ 
+-   if (fLastNormal.p == p)
+-   {
+-     return fLastNormal.vec;
+-   } 
+-   
+-   auto tmpp       = const_cast<G4ThreeVector*>(&(fLastNormal.p));
+-   auto tmpnormal  = const_cast<G4ThreeVector*>(&(fLastNormal.vec));
+-   auto tmpsurface = const_cast<G4VTwistSurface**>(fLastNormal.surface);
+-   tmpp->set(p.x(), p.y(), p.z());
+ 
+    G4double distance = kInfinity;
+ 
+@@ -490,10 +459,7 @@ G4ThreeVector G4VTwistedFaceted::SurfaceNormal(const G4ThreeVector& p) const
+       }
+    }
+ 
+-   tmpsurface[0] = surfaces[besti];
+-   *tmpnormal = tmpsurface[0]->GetNormal(bestxx, true);
+-   
+-   return fLastNormal.vec;
++   return surfaces[besti]->GetNormal(bestxx, true);
+ }
+ 
+ 
+@@ -510,26 +476,6 @@ G4double G4VTwistedFaceted::DistanceToIn (const G4ThreeVector& p,
+    // The function returns kInfinity if no intersection or
+    // just grazing within tolerance.
+ 
+-   //
+-   // checking last value
+-   //
+-   
+-   G4ThreeVector* tmpp;
+-   G4ThreeVector* tmpv;
+-   G4double* tmpdist;
+-   if (fLastDistanceToInWithV.p == p && fLastDistanceToInWithV.vec == v)
+-   {
+-      return fLastDistanceToIn.value;
+-   }
+-   else
+-   {
+-      tmpp    = const_cast<G4ThreeVector*>(&(fLastDistanceToInWithV.p));
+-      tmpv    = const_cast<G4ThreeVector*>(&(fLastDistanceToInWithV.vec));
+-      tmpdist = const_cast<G4double*>(&(fLastDistanceToInWithV.value));
+-      tmpp->set(p.x(), p.y(), p.z());
+-      tmpv->set(v.x(), v.y(), v.z());
+-   }
+-
+    //
+    // Calculate DistanceToIn(p,v)
+    //
+@@ -547,8 +493,7 @@ G4double G4VTwistedFaceted::DistanceToIn (const G4ThreeVector& p,
+      G4ThreeVector normal = SurfaceNormal(p);
+      if (normal*v < 0)
+      {
+-       *tmpdist = 0.;
+-       return fLastDistanceToInWithV.value;
++       return 0;
+      } 
+    }
+       
+@@ -574,7 +519,7 @@ G4double G4VTwistedFaceted::DistanceToIn (const G4ThreeVector& p,
+    for (const auto & surface : surfaces)
+    {
+ #ifdef G4TWISTDEBUG
+-      G4cout << G4endl << "surface " << i << ": " << G4endl << G4endl ;
++      G4cout << G4endl << "surface " << &surface - &*surfaces << ": " << G4endl << G4endl ;
+ #endif
+       G4double tmpdistance = surface->DistanceToIn(p, v, xx);
+ #ifdef G4TWISTDEBUG
+@@ -592,9 +537,8 @@ G4double G4VTwistedFaceted::DistanceToIn (const G4ThreeVector& p,
+    G4cout << "best distance = " << distance << G4endl ;
+ #endif
+ 
+-   *tmpdist = distance;
+    // timer.Stop();
+-   return fLastDistanceToInWithV.value;
++   return distance;
+ }
+ 
+ 
+@@ -608,23 +552,6 @@ G4double G4VTwistedFaceted::DistanceToIn (const G4ThreeVector& p) const
+    // allowing for tolerance
+    //
+    
+-   //
+-   // checking last value
+-   //
+-
+-   G4ThreeVector* tmpp;
+-   G4double* tmpdist;
+-   if (fLastDistanceToIn.p == p)
+-   {
+-      return fLastDistanceToIn.value;
+-   }
+-   else
+-   {
+-      tmpp    = const_cast<G4ThreeVector*>(&(fLastDistanceToIn.p));
+-      tmpdist = const_cast<G4double*>(&(fLastDistanceToIn.value));
+-      tmpp->set(p.x(), p.y(), p.z());
+-   }
+-
+    //
+    // Calculate DistanceToIn(p) 
+    //
+@@ -639,8 +566,7 @@ G4double G4VTwistedFaceted::DistanceToIn (const G4ThreeVector& p) const
+ 
+       case (kSurface) :
+       {
+-         *tmpdist = 0.;
+-         return fLastDistanceToIn.value;
++         return 0;
+       }
+ 
+       case (kOutside) :
+@@ -671,8 +597,7 @@ G4double G4VTwistedFaceted::DistanceToIn (const G4ThreeVector& p) const
+                bestxx = xx;
+             }
+          }
+-         *tmpdist = distance;
+-         return fLastDistanceToIn.value;
++         return distance;
+       }
+ 
+       default:
+@@ -702,26 +627,6 @@ G4VTwistedFaceted::DistanceToOut( const G4ThreeVector& p,
+    // The function returns kInfinity if no intersection or
+    // just grazing within tolerance.
+ 
+-   //
+-   // checking last value
+-   //
+-   
+-   G4ThreeVector* tmpp;
+-   G4ThreeVector* tmpv;
+-   G4double* tmpdist;
+-   if (fLastDistanceToOutWithV.p == p && fLastDistanceToOutWithV.vec == v  )
+-   {
+-      return fLastDistanceToOutWithV.value;
+-   }
+-   else
+-   {
+-      tmpp    = const_cast<G4ThreeVector*>(&(fLastDistanceToOutWithV.p));
+-      tmpv    = const_cast<G4ThreeVector*>(&(fLastDistanceToOutWithV.vec));
+-      tmpdist = const_cast<G4double*>(&(fLastDistanceToOutWithV.value));
+-      tmpp->set(p.x(), p.y(), p.z());
+-      tmpv->set(v.x(), v.y(), v.z());
+-   }
+-
+    //
+    // Calculate DistanceToOut(p,v)
+    //
+@@ -737,17 +642,15 @@ G4VTwistedFaceted::DistanceToOut( const G4ThreeVector& p,
+       // if the particle is exiting from the volume, return 0
+       //
+       G4ThreeVector normal = SurfaceNormal(p);
+-      G4VTwistSurface *blockedsurface = fLastNormal.surface[0];
+       if (normal*v > 0)
+       {
+             if (calcNorm)
+             {
+-               *norm = (blockedsurface->GetNormal(p, true));
+-               *validNorm = blockedsurface->IsValidNorm();
++               *norm = normal;
++               *validNorm = true;
+             }
+-            *tmpdist = 0.;
+             // timer.Stop();
+-            return fLastDistanceToOutWithV.value;
++            return 0;
+       }
+    }
+       
+@@ -789,8 +692,7 @@ G4VTwistedFaceted::DistanceToOut( const G4ThreeVector& p,
+       }
+    }
+ 
+-   *tmpdist = distance;
+-   return fLastDistanceToOutWithV.value;
++   return distance;
+ }
+ 
+ 
+@@ -802,24 +704,6 @@ G4double G4VTwistedFaceted::DistanceToOut( const G4ThreeVector& p ) const
+    // DistanceToOut(p):
+    // Calculate distance to surface of shape from `inside', 
+    // allowing for tolerance
+-
+-   //
+-   // checking last value
+-   //
+-
+-   G4ThreeVector* tmpp;
+-   G4double* tmpdist;
+-
+-   if (fLastDistanceToOut.p == p)
+-   {
+-      return fLastDistanceToOut.value;
+-   }
+-   else
+-   {
+-      tmpp    = const_cast<G4ThreeVector*>(&(fLastDistanceToOut.p));
+-      tmpdist = const_cast<G4double*>(&(fLastDistanceToOut.value));
+-      tmpp->set(p.x(), p.y(), p.z());
+-   }
+    
+    //
+    // Calculate DistanceToOut(p)
+@@ -848,8 +732,7 @@ G4double G4VTwistedFaceted::DistanceToOut( const G4ThreeVector& p ) const
+       }
+       case (kSurface) :
+       {
+-        *tmpdist = 0.;
+-        retval = fLastDistanceToOut.value;
++        retval = 0;
+         break;
+       }
+       
+@@ -881,9 +764,7 @@ G4double G4VTwistedFaceted::DistanceToOut( const G4ThreeVector& p ) const
+             bestxx = xx;
+           }
+         }
+-        *tmpdist = distance;
+-   
+-        retval = fLastDistanceToOut.value;
++        retval = distance;
+         break;
+       }
+       

--- a/packages/k4actstracking/package.py
+++ b/packages/k4actstracking/package.py
@@ -13,7 +13,7 @@ class K4actstracking(CMakePackage, Key4hepPackage):
     maintainers("vvolkl")
 
     version("main", branch="main")
-    version("gnn", branch="gnn-trackfinding-on-main")
+    version("gnn", branch="gnn-tracking-pipeline")
 
     version(
         "00-04",
@@ -34,20 +34,28 @@ class K4actstracking(CMakePackage, Key4hepPackage):
 
     depends_on("cxx", type="build")
 
+    variant(
+        "gnn",
+        default=False,
+        description="Build the GNN track finding pipeline",
+    )
+
     depends_on("acts+dd4hep+json")
     # The GNN tracking pipeline is the only consumer of the acts GNN plugin.
-    depends_on("acts+dd4hep+json+gnn+onnx+torch", when="@gnn")
+    depends_on("acts+dd4hep+json+gnn+onnx+torch", when="+gnn")
     depends_on("gaudi")
     depends_on("root")
     depends_on("edm4hep")
     depends_on("k4fwcore")
     depends_on("opendatadetector", type="test")
     # The ML inference dependencies are only needed by the GNN tracking pipeline.
-    depends_on("py-torch", when="@gnn")
-    depends_on("py-onnxruntime", when="@gnn")
+    depends_on("py-torch", when="+gnn")
+    depends_on("py-onnxruntime", when="+gnn")
 
     def cmake_args(self):
-        return []
+        return [
+            self.define_from_variant("K4ACTSTRACKING_BUILD_GNN", "gnn"),
+        ]
 
     def setup_run_environment(self, env):
         env.prepend_path("PYTHONPATH", self.prefix.python)

--- a/packages/mucoll-stack/package.py
+++ b/packages/mucoll-stack/package.py
@@ -67,6 +67,7 @@ class MucollStack(BundlePackage, Key4hepPackage):
         #######################################################
         depends_on('dd4hep')
         depends_on('delphes')
+        depends_on('hepmc3')
 
         depends_on('k4geo')
         depends_on('k4reco')
@@ -116,7 +117,6 @@ class MucollStack(BundlePackage, Key4hepPackage):
 
     with when('+gen'):
         depends_on('whizard +lcio +openloops')
-        depends_on('hepmc3')
 
     ##################### developer tools #################
     #######################################################

--- a/packages/mucoll-stack/package.py
+++ b/packages/mucoll-stack/package.py
@@ -112,6 +112,7 @@ class MucollStack(BundlePackage, Key4hepPackage):
         #######################################################
         depends_on('muoncvxddigitiser')
         depends_on('mybibutils')
+        depends_on('acorn')
 
     with when('+gen'):
         depends_on('whizard +lcio +openloops')
@@ -126,14 +127,12 @@ class MucollStack(BundlePackage, Key4hepPackage):
     depends_on('llvm', when='+llvm')
 
     with when('+ml'):
-        #depends_on("k4mltracking")
         # ML tools
         depends_on('onnx')
         depends_on('xgboost')
         depends_on('py-onnxruntime')
         depends_on('py-onnx')
         depends_on("py-torch")
-        depends_on('acorn')
         depends_on('torch-scatter')
         depends_on('py-torch-scatter')
         depends_on('py-scikit-learn')

--- a/packages/mucoll-stack/package.py
+++ b/packages/mucoll-stack/package.py
@@ -44,7 +44,6 @@ class MucollStack(BundlePackage, Key4hepPackage):
     variant('llvm', default=False, description='Build with LLVM')
     variant('ml', default=False, description='Build with machine learning tools')
     variant('pytools', default=False, description='Build with python tools')
-    variant('analysis', default=False, description='Minimal build for analysis only')
     variant('sim', default=False, description='Build with reconstruction and simulation tools')
     variant('gen', default=False, description='Build with generators')
 
@@ -59,9 +58,9 @@ class MucollStack(BundlePackage, Key4hepPackage):
     depends_on('ccache')
     depends_on('ninja')
 
-    with when('+analysis'):
-        depends_on('edm4hep')
-        depends_on('podio')
+    # Minimal build for analysis only
+    depends_on('edm4hep')
+    depends_on('podio')
 
     with when('+sim'):
         ############################### Key4hep ###############


### PR DESCRIPTION
I was struck by @mattleblanc's remark on how the ML tools should probably be into the analysis image (when discussing https://indico.muoncollider.us/event/41/contributions/361/attachments/167/269/20260630_MLB_AI4MuC.pdf).

I agree very much and this seemed also like a good chance to simplify a bit the workflow, so here it is.

This PR moves the ML tools over to analysis. Furthermore, it now builds a single version of k4actstracking, since most features we needed have landed upstream.

This temporarily includes also a geant4 recipe to allow to build without examples (to be removed when https://github.com/spack/spack-packages/pull/5445 is merged)