### PR TITLE
Add k4clue@main to mucoll-spack

### DIFF
--- a/environments/mucoll-common/packages.yaml
+++ b/environments/mucoll-common/packages.yaml
@@ -193,6 +193,8 @@ packages:
     require: '@main+gnn'
   k4simgeant4:
     require: '@main'
+  k4clue:
+    require: '@main'
 
   lccontent:
     require: +monitoring

--- a/packages/mucoll-stack/package.py
+++ b/packages/mucoll-stack/package.py
@@ -76,6 +76,7 @@ class MucollStack(BundlePackage, Key4hepPackage):
         # k4SimGeant4 provides the GeoSvc that the MAIA/MuColl reconstruction
         # workflow loads at runtime (with EnableGeant4Geo=False).
         depends_on('k4simgeant4')
+        depends_on('k4clue')
         #depends_on('k4marlinwrapper')
 
         ############################### ILCSoft ###############


### PR DESCRIPTION
This probably won't work unless our version of key4hep-spack has [this change](https://github.com/key4hep/key4hep-spack/pull/913) merged in though. See [here](https://github.com/MuonColliderSoft/MAIAConfig) for more details on the use of CLUE.