### PR TITLE
Adding physics benchmarks and fast-feedback to validation CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,11 +1,4 @@
 name: Build MuColl Stack and Publish Image
-description: |
-  Publish the layered mucoll software stack docker images:
-  mucoll-analysis -> mucoll-sim.
-  The +sim variant covers both reconstruction and simulation; there is no
-  separate reco image.
-  Each layer is built FROM the previous one (per architecture) so packages are
-  installed once and reused down the chain. Relies on a spack buildcache.
 
 on:
   # Build/publish the image when changes land on main; run on pull requests (so
@@ -97,10 +90,25 @@ jobs:
       amd64-image: ${{ needs.sim-amd64.outputs.image-uri }}
       arm64-image: ${{ needs.sim-arm64.outputs.image-uri }}
 
+  # ------------------------------------------------------ PR fast validation --
+  physics-fast:
+    # Pull requests get one fast, report-only pion chain against the freshly
+    # published image while the full validation runs alongside it.
+    needs: manifest-sim
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: ./.github/workflows/physics-fast.yaml
+    with:
+      image: ${{ needs.manifest-sim.outputs.image }}
+      pdg: "211"
+      geometry: MAIA_v0
+      n-events: "10"
+      benchmarks-ref: main
+
   # ------------------------------------------------------ physics validation --
   physics-validation:
     # Run the sim -> digi -> reco -> plot chain against the freshly published
-    # multi-arch sim image, gated on the successful sim manifest build.
+    # multi-arch sim image after merges, manual builds, and same-repository pull
+    # requests. Pull requests also get the quicker validation above.
     needs: manifest-sim
     # Skip on fork PRs: the image isn't pushed there, so there is nothing to pull
     # and validate (fork PRs build the image but cannot push it).

--- a/.github/workflows/physics-fast.yaml
+++ b/.github/workflows/physics-fast.yaml
@@ -164,9 +164,13 @@ jobs:
               source /opt/setup_mucoll.sh >/dev/null 2>&1
               bash /work/validation/make_plots.sh "${PARTICLE}"
               fragment_args=()
-              for fragment in /work/metric-fragments/metrics_*.json; do
+              while IFS= read -r fragment; do
                 fragment_args+=(--fragment "${fragment}")
-              done
+              done < <(find /work/metric-fragments -name "metrics_*.json" -type f -print | sort)
+              if [ "${#fragment_args[@]}" -eq 0 ]; then
+                echo "ERROR: no metrics fragments were produced" >&2
+                exit 1
+              fi
               python /work/benchmarks/analysis/benchmarks/aggregate_metrics.py \
                 --expected-events "${NEV}" \
                 --sample-label "${PARTICLE}" \

--- a/.github/workflows/physics-fast.yaml
+++ b/.github/workflows/physics-fast.yaml
@@ -1,0 +1,259 @@
+name: Fast physics validation
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: "Container image to test"
+        required: true
+        type: string
+      pdg:
+        description: "Particle-gun PDG id"
+        required: false
+        type: string
+        default: "211"
+      geometry:
+        description: "Detector geometry name"
+        required: false
+        type: string
+        default: MAIA_v0
+      n-events:
+        description: "Number of events"
+        required: false
+        type: string
+        default: "10"
+      benchmarks-ref:
+        description: "mucoll-benchmarks branch, tag, or commit"
+        required: false
+        type: string
+        default: main
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  fast-validation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Resolve particle label
+        id: meta
+        env:
+          PDG: ${{ inputs.pdg }}
+        run: |
+          apdg=${PDG#-}
+          case "$apdg" in
+            11) particle=electron ;;
+            13) particle=muon ;;
+            211) particle=pion ;;
+            22) particle=photon ;;
+            *) echo "Unsupported particle PDG: ${PDG}" >&2; exit 2 ;;
+          esac
+          echo "particle=${particle}" >> "$GITHUB_OUTPUT"
+
+      - name: Free disk space
+        uses: endersonmenezes/free-disk-space@v3
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: true
+          remove_swap: true
+          remove_packages: "azure-cli google-cloud-cli microsoft-edge-stable google-chrome-stable firefox postgresql* temurin-* *llvm* mysql* dotnet-sdk-*"
+          remove_packages_one_command: true
+          remove_folders: "/usr/share/swift /usr/share/miniconda /usr/share/az* /usr/local/lib/node_modules /usr/local/share/chromium /usr/local/share/powershell /usr/local/julia /usr/local/aws-cli /usr/local/aws-sam-cli /usr/share/gradle"
+          rm_cmd: rmz
+          rmz_version: "3.1.1"
+          testing: false
+
+      - name: Check out mucoll-spack
+        uses: actions/checkout@v6
+
+      - name: Check out mucoll-benchmarks
+        uses: actions/checkout@v6
+        with:
+          repository: MuonColliderSoft/mucoll-benchmarks
+          ref: ${{ inputs.benchmarks-ref }}
+          path: benchmarks
+          submodules: recursive
+
+      - name: Download generated input
+        env:
+          PARTICLE: ${{ steps.meta.outputs.particle }}
+        run: |
+          curl -fSL --retry 3 -o gen.edm4hep.root \
+            "https://github.com/MuonColliderSoft/mucoll-spack/releases/download/phys-val-inputs/gen-${PARTICLE}.edm4hep.root"
+
+      - name: Launch container once
+        env:
+          IMAGE: ${{ inputs.image }}
+        run: |
+          docker run -d --name ci --privileged --entrypoint tail \
+            -v "${GITHUB_WORKSPACE}:/work" -w /work "${IMAGE}" -f /dev/null
+          docker inspect --format='image_id={{.Image}}' ci | tee container.log
+
+      - name: Simulation
+        env:
+          GEOMETRY: ${{ inputs.geometry }}
+          N_EVENTS: ${{ inputs.n-events }}
+        run: |
+          docker exec -w /work \
+            -e BM=/work/benchmarks -e GEOM="${GEOMETRY}" -e NEV="${N_EVENTS}" \
+            ci /bin/bash /work/validation/run_chain.sh sim 2>&1 | tee sim.log
+
+      - name: Digitisation
+        env:
+          GEOMETRY: ${{ inputs.geometry }}
+          N_EVENTS: ${{ inputs.n-events }}
+        run: |
+          docker exec -w /work \
+            -e BM=/work/benchmarks -e GEOM="${GEOMETRY}" -e NEV="${N_EVENTS}" \
+            ci /bin/bash /work/validation/run_chain.sh digi 2>&1 | tee digi.log
+
+      - name: Reconstruction
+        env:
+          GEOMETRY: ${{ inputs.geometry }}
+          N_EVENTS: ${{ inputs.n-events }}
+        run: |
+          docker exec -w /work \
+            -e BM=/work/benchmarks -e GEOM="${GEOMETRY}" -e NEV="${N_EVENTS}" \
+            ci /bin/bash /work/validation/run_chain.sh reco 2>&1 | tee reco.log
+
+      - name: Record production provenance
+        env:
+          IMAGE: ${{ inputs.image }}
+          GEOMETRY: ${{ inputs.geometry }}
+          N_EVENTS: ${{ inputs.n-events }}
+          PARTICLE: ${{ steps.meta.outputs.particle }}
+          PDG: ${{ inputs.pdg }}
+        run: |
+          input_url="https://github.com/MuonColliderSoft/mucoll-spack/releases/download/phys-val-inputs/gen-${PARTICLE}.edm4hep.root"
+          image_id="$(docker inspect --format='{{.Image}}' ci)"
+          image_platform="$(docker image inspect --format='{{.Os}}/{{.Architecture}}' "${image_id}")"
+          python3 validation/write_provenance.py \
+            --input gen.edm4hep.root \
+            --input-source "${input_url}" \
+            --events "${N_EVENTS}" \
+            --particle "${PARTICLE}" \
+            --pdg "${PDG}" \
+            --geometry "${GEOMETRY}" \
+            --image-reference "${IMAGE}" \
+            --image-id "${image_id}" \
+            --image-platform "${image_platform}" \
+            --benchmarks-revision "$(git -C benchmarks rev-parse HEAD)" \
+            --spack-revision "${GITHUB_SHA}" \
+            --output submission.json
+
+      - name: Run studies and aggregate report-only metrics
+        env:
+          GEOMETRY: ${{ inputs.geometry }}
+          N_EVENTS: ${{ inputs.n-events }}
+          PARTICLE: ${{ steps.meta.outputs.particle }}
+          PDG: ${{ inputs.pdg }}
+        run: |
+          docker exec -w /work \
+            -e BM=/work/benchmarks -e GEOM="${GEOMETRY}" \
+            -e NEV="${N_EVENTS}" -e PARTICLE="${PARTICLE}" -e PDG="${PDG}" \
+            -e PLOT_RUN_DIR=/work/metric-fragments \
+            -e PLOT_OUT_DIR=/work/metric-plots \
+            ci /bin/bash -lc '
+              source /opt/setup_mucoll.sh >/dev/null 2>&1
+              bash /work/validation/make_plots.sh "${PARTICLE}"
+              fragment_args=()
+              for fragment in /work/metric-fragments/metrics_*.json; do
+                fragment_args+=(--fragment "${fragment}")
+              done
+              python /work/benchmarks/analysis/benchmarks/aggregate_metrics.py \
+                --expected-events "${NEV}" \
+                --sample-label "${PARTICLE}" \
+                --input /work/reco.edm4hep.root \
+                --production-metadata /work/submission.json \
+                "${fragment_args[@]}" \
+                --output /work/metrics.json
+            ' 2>&1 | tee metrics.log
+
+      - name: Validate and summarize metrics
+        env:
+          N_EVENTS: ${{ inputs.n-events }}
+          PARTICLE: ${{ steps.meta.outputs.particle }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          with open("metrics.json", encoding="utf-8") as source:
+              report = json.load(source)
+          particle = os.environ["PARTICLE"]
+          sample = report["samples"][particle]
+          expected = int(os.environ["N_EVENTS"])
+          if sample["event_count"] != expected:
+              raise SystemExit(
+                  "expected {} events, found {}".format(expected, sample["event_count"])
+              )
+          studies = sample["studies"]
+          rows = [("Particle", particle), ("Events", sample["event_count"])]
+          if "tracks" in studies:
+              tracks = studies["tracks"]["metrics"]
+              rows.extend([
+                  ("Tracking efficiency", "{:.3f}".format(tracks["tracking_efficiency"])),
+                  ("Track fake rate", "{:.3f}".format(tracks["fake_rate"])),
+                  ("Mean selected tracks/event", "{:.3f}".format(
+                      tracks["track_multiplicity"]["mean"])),
+              ])
+          if "seeds" in studies:
+              seeds = studies["seeds"]["metrics"]
+              rows.append(("Matched seed fraction", "{:.3f}".format(
+                  seeds["matched_fraction"])))
+          if "hits" in studies:
+              hits = studies["hits"]["metrics"]
+              rows.append(("Mean tracker hits/event", "{:.3f}".format(
+                  hits["total_hit_multiplicity"]["mean"])))
+          if "photons" in studies:
+              photons = studies["photons"]["metrics"]
+              rows.extend([
+                  ("Photon reconstruction efficiency", "{:.3f}".format(
+                      photons["reconstruction_efficiency"])),
+                  ("Mean PFO multiplicity", "{:.3f}".format(
+                      photons["pfo_multiplicity"]["mean"])),
+              ])
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("## Fast physics validation\n\n")
+              summary.write("| Metric | Value |\n|---|---:|\n")
+              for name, value in rows:
+                  summary.write("| {} | {} |\n".format(name, value))
+          PY
+
+      - name: Record disk and output sizes
+        if: always()
+        run: |
+          {
+            df -h /
+            docker system df
+            du -h ./*.edm4hep.root 2>/dev/null || true
+          } | tee resources.log
+
+      - name: Upload fast-validation report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: physics-fast-${{ steps.meta.outputs.particle }}
+          path: |
+            metrics.json
+            metric-fragments/metrics_*.json
+            submission.json
+            container.log
+            sim.log
+            digi.log
+            reco.log
+            metrics.log
+            resources.log
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f ci 2>/dev/null || true

--- a/.github/workflows/physics-validation-template.yaml
+++ b/.github/workflows/physics-validation-template.yaml
@@ -1,14 +1,8 @@
 name: Physics validation
-description: |
-  Reusable per-particle physics-validation pipeline.
-  Runs sim -> digi -> reco as independent jobs (each gets a fresh runner time
-  budget), forwarding the output of each stage to the next as an artifact. The
-  generator-level input is not produced here (the gun exercises no release code):
-  sim downloads a pre-generated per-particle file. 
 
-  The mucoll-sim image is large, so jobs do NOT use a job-level `container:`
-  (which pulls before any step runs and exhausts the runner disk). Instead each
-  job frees disk first, then launches the container manually with docker run/exec.
+# Reusable per-particle physics-validation pipeline. SIM, DIGI, and RECO run as
+# independent jobs, forwarding their output and production provenance as
+# artifacts. The large image is launched manually after each job frees disk.
 
 on:
   workflow_call:
@@ -113,10 +107,36 @@ jobs:
             -e GEOM="${{ inputs.geometry }}" \
             -e NEV="${{ inputs.n-events }}" \
             ci /bin/bash /work/validation/run_chain.sh sim
+      - name: Record production provenance
+        env:
+          IMAGE: ${{ inputs.image }}
+          GEOMETRY: ${{ inputs.geometry }}
+          N_EVENTS: ${{ inputs.n-events }}
+          PARTICLE: ${{ needs.meta.outputs.particle }}
+          PDG: ${{ inputs.pdg }}
+        run: |
+          input_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/phys-val-inputs/gen-${PARTICLE}.edm4hep.root"
+          image_id="$(docker inspect --format='{{.Image}}' ci)"
+          image_platform="$(docker image inspect --format='{{.Os}}/{{.Architecture}}' "${image_id}")"
+          python3 validation/write_provenance.py \
+            --input gen.edm4hep.root \
+            --input-source "${input_url}" \
+            --events "${N_EVENTS}" \
+            --particle "${PARTICLE}" \
+            --pdg "${PDG}" \
+            --geometry "${GEOMETRY}" \
+            --image-reference "${IMAGE}" \
+            --image-id "${image_id}" \
+            --image-platform "${image_platform}" \
+            --benchmarks-revision "$(git -C benchmarks rev-parse HEAD)" \
+            --spack-revision "${GITHUB_SHA}" \
+            --output submission.json
       - uses: actions/upload-artifact@v7
         with:
           name: sim-${{ needs.meta.outputs.particle }}
-          path: sim.edm4hep.root
+          path: |
+            sim.edm4hep.root
+            submission.json
           if-no-files-found: error
 
   digi:
@@ -161,7 +181,9 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: digi-${{ needs.meta.outputs.particle }}
-          path: digi.edm4hep.root
+          path: |
+            digi.edm4hep.root
+            submission.json
           if-no-files-found: error
 
   reco:
@@ -206,7 +228,9 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: reco-${{ needs.meta.outputs.particle }}
-          path: reco.edm4hep.root
+          path: |
+            reco.edm4hep.root
+            submission.json
           if-no-files-found: error
 
   plot:
@@ -249,6 +273,36 @@ jobs:
             -e NEV="${{ inputs.n-events }}" \
             -e PDG="${{ inputs.pdg }}" \
             ci /bin/bash /work/validation/make_plots.sh "${{ needs.meta.outputs.particle }}"
+      - name: Aggregate report-only metrics
+        env:
+          N_EVENTS: ${{ inputs.n-events }}
+          PARTICLE: ${{ needs.meta.outputs.particle }}
+        run: |
+          docker exec -w /work \
+            -e N_EVENTS="${N_EVENTS}" -e PARTICLE="${PARTICLE}" \
+            ci /bin/bash -lc '
+              source /opt/setup_mucoll.sh >/dev/null 2>&1
+              fragment_args=()
+              while IFS= read -r fragment; do
+                fragment_args+=(--fragment "${fragment}")
+              done < <(find /work/plot_work -name "metrics_*.json" -type f -print | sort)
+              python /work/benchmarks/analysis/benchmarks/aggregate_metrics.py \
+                --sample-label "${PARTICLE}" \
+                --input /work/reco.edm4hep.root \
+                --expected-events "${N_EVENTS}" \
+                --production-metadata /work/submission.json \
+                "${fragment_args[@]}" \
+                --output /work/metrics.json
+            '
+      - name: Upload benchmark metrics
+        uses: actions/upload-artifact@v7
+        with:
+          name: metrics-${{ needs.meta.outputs.particle }}
+          path: |
+            metrics.json
+            submission.json
+            plot_work/**/metrics_*.json
+          if-no-files-found: error
       - name: Upload plots (per-particle Pages fragment)
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/physics-validation.yaml
+++ b/.github/workflows/physics-validation.yaml
@@ -1,16 +1,19 @@
 name: Physics validation (manual)
-description: |
-  Manually trigger the per-particle physics-validation chain
-  (sim -> digi -> reco -> plot; the gun input is pre-generated and downloaded)
-  against a chosen image, via the reusable physics-validation-template workflow.
 
 on:
   workflow_dispatch:
     inputs:
+      mode:
+        description: "Validation scale"
+        type: choice
+        default: fast
+        options:
+          - fast
+          - full
       pdg:
         description: "Particle gun PDG id (label is inferred from it)"
         type: choice
-        default: "13"
+        default: "211"
         options:
           - "13"    # muon
           - "11"     # electron
@@ -27,13 +30,28 @@ on:
       n-events:
         description: "Number of events to simulate"
         type: string
-        default: "1000"
+        default: "10"
+      benchmarks-ref:
+        description: "mucoll-benchmarks branch, tag, or commit (fast mode)"
+        type: string
+        default: main
 
 permissions:
   contents: read
 
 jobs:
+  physics-fast:
+    if: inputs.mode == 'fast'
+    uses: ./.github/workflows/physics-fast.yaml
+    with:
+      image: ${{ inputs.image }}
+      pdg: ${{ inputs.pdg }}
+      geometry: ${{ inputs.geometry }}
+      n-events: ${{ inputs.n-events }}
+      benchmarks-ref: ${{ inputs.benchmarks-ref }}
+
   physics-validation:
+    if: inputs.mode == 'full'
     uses: ./.github/workflows/physics-validation-template.yaml
     with:
       image: ${{ inputs.image }}

--- a/validation/README.md
+++ b/validation/README.md
@@ -1,0 +1,47 @@
+# Physics validation workflows
+
+Muon Collider image validation has two distinct scales:
+
+| Workflow | Purpose | Default sample | Layout |
+|---|---|---:|---|
+| `physics-fast.yaml` | Fast integration check for a proposed image | 10 pion events | SIM, DIGI, RECO, and metrics in one job |
+| `physics-validation-template.yaml` | Release or scheduled performance study | Configurable, normally high statistics | Separate SIM, DIGI, RECO, and plotting/metrics jobs |
+
+The fast workflow pulls the container once, runs the appropriate EDM4hep
+studies, and uploads logs, production provenance, the per-study JSON fragments,
+and their aggregate `metrics.json`. Its metrics are report-only: the job checks
+that the requested event count was processed, but it does not yet compare
+physics values with reference tolerances.
+
+The workflow uses immutable particle-gun inputs from the `phys-val-inputs`
+release. The studies write sidecars and
+`mucoll-benchmarks/analysis/benchmarks/aggregate_metrics.py` combines them with
+the stack, container, input, geometry, source, and GitHub run provenance. The
+`benchmarks-ref` input can select a branch or commit while changes are being
+reviewed.
+
+The split full-validation workflow creates `submission.json` in the SIM job and
+carries it with the stage artifacts through DIGI and RECO. Its final plot job
+uploads a `metrics-<particle>` artifact containing the aggregate report, the
+per-study fragments, and that production record. The fast and full workflows
+share `validation/write_provenance.py` so they record the same metadata schema.
+
+The active `physics-validation.yaml` manual workflow launches either mode. The
+image-build workflow also calls the fast validation against freshly built images for
+same-repository pull requests. Those pull requests, pushes to `main`, and manual
+image builds also run the split, high-statistics workflow. Both PR validation
+paths reuse the image produced by the same build. Fork pull requests skip
+physics execution because they cannot publish an image for a downstream job to
+pull.
+
+## When each validation runs
+
+| Event | Validation |
+|---|---|
+| Pull request from this repository | Fast validation plus full four-particle validation, both using the same newly built image |
+| Push to `main` | Full validation: the default event count for each of muon, electron, pion, and photon |
+| Manual run of `build.yaml` | Full validation against the newly built image |
+| Manual run of `physics-validation.yaml` | The selected `fast` or `full` mode for one particle and event count |
+| Pull request from a fork | No physics validation, because its image cannot be published for a downstream job |
+
+No validation is currently triggered by a pull-request label.

--- a/validation/make_plots.sh
+++ b/validation/make_plots.sh
@@ -32,6 +32,7 @@
 #   PLOT_OUT_DIR=/path/to/public/plots/dir
 #   PLOT_SUFFIX=png|pdf|...
 #   PLOT_LABEL=<provenance label stamped on every plot>
+# The run directory also receives one metrics_<study>.json sidecar per study.
 ###############################################################################
 set -euo pipefail
 
@@ -160,6 +161,7 @@ run_study() {
     -i reco.edm4hep.root \
     -o "${RUN_DIR}/histos_${name}.root" \
     -d "${OUT}" \
+    --metrics "${RUN_DIR}/metrics_${name}.json" \
     --label "${LABEL}" \
     --suffix "${PLOT_SUFFIX}" \
     "$@"
@@ -200,7 +202,11 @@ if [ "${PARTICLE}" = "photon" ]; then
     exit 1
   fi
   echo "--- study_photons.py ---"
-  python "${PHOTON_SCRIPT}" -i reco.edm4hep.root -o "${RUN_DIR}/histos_photons.root" -d "${OUT}"
+  python "${PHOTON_SCRIPT}" \
+    -i reco.edm4hep.root \
+    -o "${RUN_DIR}/histos_photons.root" \
+    -d "${OUT}" \
+    --metrics "${RUN_DIR}/metrics_photons.json"
   write_index "${OUT}" "${PARTICLE}" "${PLOT_SUFFIX}"
   echo "=== plotting ${PARTICLE} done ==="
   ls -lh "${OUT}" || true

--- a/validation/write_provenance.py
+++ b/validation/write_provenance.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Write reproducible production metadata for a physics-validation chain."""
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import pathlib
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def github_metadata(environment=None):
+    environment = os.environ if environment is None else environment
+    mapping = {
+        "repository": "GITHUB_REPOSITORY",
+        "workflow": "GITHUB_WORKFLOW",
+        "job": "GITHUB_JOB",
+        "event": "GITHUB_EVENT_NAME",
+        "run_id": "GITHUB_RUN_ID",
+        "run_attempt": "GITHUB_RUN_ATTEMPT",
+        "sha": "GITHUB_SHA",
+        "ref": "GITHUB_REF",
+    }
+    return {
+        key: environment[source]
+        for key, source in mapping.items()
+        if environment.get(source)
+    }
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=pathlib.Path)
+    parser.add_argument("--input-source", required=True)
+    parser.add_argument("--events", required=True, type=int)
+    parser.add_argument("--particle", required=True)
+    parser.add_argument("--pdg", required=True, type=int)
+    parser.add_argument("--geometry", required=True)
+    parser.add_argument("--image-reference", required=True)
+    parser.add_argument("--image-id", required=True)
+    parser.add_argument("--image-platform", required=True)
+    parser.add_argument("--benchmarks-revision", required=True)
+    parser.add_argument("--spack-revision", required=True)
+    parser.add_argument("--output", default="submission.json", type=pathlib.Path)
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    if not args.input.is_file():
+        raise SystemExit("input file not found: {}".format(args.input))
+    if args.events < 0:
+        raise SystemExit("--events must be non-negative")
+    metadata = {
+        "schema_version": 1,
+        "generated_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "input": {
+            "path": args.input.name,
+            "source": args.input_source,
+            "bytes": args.input.stat().st_size,
+            "sha256": sha256(args.input),
+        },
+        "events": args.events,
+        "particle": args.particle,
+        "pdg": args.pdg,
+        "geometry": args.geometry,
+        "container": {
+            "reference": args.image_reference,
+            "image_id": args.image_id,
+            "platform": args.image_platform,
+        },
+        "revisions": {
+            "mucoll_benchmarks": args.benchmarks_revision,
+            "mucoll_spack": args.spack_revision,
+        },
+        "github": github_metadata(),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(metadata, allow_nan=False, indent=2, sort_keys=True) + "\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/write_provenance.py
+++ b/validation/write_provenance.py
@@ -85,7 +85,8 @@ def main(argv=None):
     }
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(
-        json.dumps(metadata, allow_nan=False, indent=2, sort_keys=True) + "\n"
+        json.dumps(metadata, allow_nan=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
     )
 
 


### PR DESCRIPTION
This PR adds structured, report-only physics metrics and a fast feedback path to the existing mucoll-spack physics validation.

For same-repository pull requests, the workflow builds the proposed image once and then runs:
  - Fast validation: a 10-event pion SIM → DIGI → RECO chain in one job.
  - Full validation: the existing four-particle, higher-statistics pipeline.

Both validations use the same newly built image.

## Changes

  - Add a reusable fast-validation workflow.
  - Preserve the existing full validation on same-repository pull requests.
  - Produce per-study JSON metric fragments and an aggregate metrics.json.
  - Add JSON metrics to the existing full-validation pipeline.
  - Record reproducibility metadata, including:
    - container reference, digest, and platform;
    - input source, size, and SHA-256;
    - geometry, particle, PDG ID, and event count;
    - mucoll-spack and mucoll-benchmarks revisions;
    - GitHub Actions run identifiers.
  - Carry production provenance through SIM, DIGI, and RECO artifacts.
  - Upload metrics, provenance, and logs as workflow artifacts.
  - Allow manual selection between fast and full validation.
  - Document the validation modes and triggers.

## Triggers

  - Same-repository PR: fast and full validation against the PR image.
  - Push to main: full four-particle validation.
  - Manual image build: full validation against the newly built image.
  - Manual physics-validation run: selected fast or full mode against an existing image.
  - Fork PR: no physics validation because its image cannot be published for downstream jobs.
  - 
No label trigger or additional image build is introduced.

## Current scope

The generated metrics are report-only. Validation currently fails if the production chain fails, expected outputs are missing, metric aggregation fails, or the processed event count is incorrect. It does not (yet) block PRs based on the report.

## Follow-up

After collecting stable higher-statistics results, I'll define reference values and tolerances in a PR to mucoll-benchmarks. The full pre-merge validation can then compare the PR image against those tolerances and act as a validation step.